### PR TITLE
Rewrite print mechanics in Luau; fix cyclic print stack overflow bug

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -5,6 +5,7 @@
 	},
 	"aliases": {
 		"std": "./.typedefs/std/",
+		"interop": "./.typedefs/interop/",
 		"tests": "./tests/luau/",
 		"data": "./tests/data/"
 	}

--- a/.typedefs/interop/mlua.luau
+++ b/.typedefs/interop/mlua.luau
@@ -3,7 +3,11 @@ Interop with seal's underlying mlua layer
 ]=]
 local mlua = {}
 
---- Returns `true` if `n` is an mlua Int, or `false` if it's an `mlua` Number
+--- Returns `true` if `n` is an mlua Integer, or `false` if it's an `mlua` Number
+---
+--- Note, this is important (and therefore annoying) because large integer numbers, 
+--- such as `1231231231234445` are internally represented as mlua `LuaNumber`s and not mlua `LuaInteger`s; 
+--- this breaks Rust-side functions that expect a `LuaInteger` and don't properly handle the `LuaNumber` case.
 @checked
 function mlua.isint(n: number): boolean
 	return nil :: any

--- a/.typedefs/interop/mlua.luau
+++ b/.typedefs/interop/mlua.luau
@@ -13,4 +13,10 @@ function mlua.isint(n: number): boolean
 	return nil :: any
 end
 
+--- Returns `true` if `e` is an mlua Error, false otherwise
+@checked
+function mlua.iserror(e: any): boolean
+	return nil :: any
+end
+
 return mlua

--- a/.typedefs/interop/mlua.luau
+++ b/.typedefs/interop/mlua.luau
@@ -1,0 +1,12 @@
+--[=[
+Interop with seal's underlying mlua layer
+]=]
+local mlua = {}
+
+--- Returns `true` if `n` is an mlua Int, or `false` if it's an `mlua` Number
+@checked
+function mlua.isint(n: number): boolean
+	return nil :: any
+end
+
+return mlua

--- a/.typedefs/std/io/colors.luau
+++ b/.typedefs/std/io/colors.luau
@@ -29,6 +29,11 @@ export type colors = {
         white: (text: string) -> string,
     },
 
+    style: {
+        dim: (text: string) -> string,
+        bold: (text: string) -> string,
+    },
+
     codes: {
         RESET: "\x1b[0m",
         BLACK: "\x1b[30m",
@@ -71,10 +76,12 @@ export type colors = {
         BRIGHT_MAGENTA_BG: "\x1b[105m",
         BRIGHT_CYAN_BG: "\x1b[106m",
         BRIGHT_WHITE_BG: "\x1b[107m",
+        BOLD: "\x1b[1m",
+        DIM: "\x1b[2m",
     }
 }
 
--- yeah so apparently you can't put moonwave docs in typedes so please
+-- yeah so apparently you can't put moonwave docs in typedefs so please
 -- don't pray for my sanity wrt. the below code because even tho copilot couldn't handle it 
 -- i used a luau script (with this runtime ofc)
 
@@ -345,5 +352,7 @@ colors.codes = {
 	BRIGHT_MAGENTA_BG = "\x1b[105m",
 	BRIGHT_CYAN_BG = "\x1b[106m",
 	BRIGHT_WHITE_BG = "\x1b[107m",
+    BOLD = "\x1b[1m",
+    DIM = "\x1b[2m",
 }
 return colors

--- a/.typedefs/std/io/output.luau
+++ b/.typedefs/std/io/output.luau
@@ -23,12 +23,27 @@ output["debug-print"]({
 ]=]
 local output = {}
 
---- prettifies and colorizes any Luau values in the same way as `print`
-function output.format(...: any): ...string
+--- prettifies and colorizes any Luau value in the same way as `print`
+function output.format(v: any): ...string
 	return nil :: any
 end
 
---- an uncolorized print for debugging that returns the printed values; same as the included global `p`.
+--- reverts output.format or colorizing from print/pp
+function output.unformat(v: any): string
+	return nil :: any
+end
+
+--- simple print and return; equivalent to `p`
+function output.sprint<T>(v: T): T
+	return nil :: any
+end
+
+--- formats any value in simple format style (equivalent to `p`)
+function output.sformat(v: any): string
+	return nil :: any
+end
+
+--- an uncolorized print for debugging that returns the printed values
 output["debug-print"] = function(...: any): ...string
 	return nil :: any
 end

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -18,7 +18,7 @@ pub fn set_globals(luau: &Lua) -> LuaValueResult {
     let luau_version: LuaString = globals.raw_get("_VERSION")?;
     globals.raw_set("require", luau.create_function(require::require)?)?;
     globals.raw_set("error", luau.create_function(error)?)?;	
-    globals.raw_set("p", luau.create_function(std_io_output::debug_print)?)?;
+    globals.raw_set("p", luau.create_function(std_io_output::simple_print_and_return)?)?;
     globals.raw_set("pp", luau.create_function(std_io_output::pretty_print_and_return)?)?;
     globals.raw_set("print", luau.create_function(std_io_output::pretty_print)?)?;
     globals.raw_set("warn", luau.create_function(warn)?)?;

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -15,9 +15,21 @@ fn interop_mlua_isint(_luau: &Lua, n: LuaValue) -> LuaValueResult {
     }
 }
 
+fn interop_mlua_iserror(_luau: &Lua, value: LuaValue) -> LuaValueResult {
+    match value {
+        LuaValue::Error(_err) => {
+            Ok(LuaValue::Boolean(true))
+        },
+        _other => {
+            Ok(LuaValue::Boolean(false))
+        }
+    }
+}
+
 pub fn create_mlua(luau: &Lua) -> LuaResult<LuaTable> {
     TableBuilder::create(luau)?
         .with_function("isint", interop_mlua_isint)?
+        .with_function("iserror", interop_mlua_iserror)?
         .build_readonly()
 }
 

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,0 +1,28 @@
+use mlua::prelude::*;
+use crate::{table_helpers::TableBuilder, LuaValueResult, colors, wrap_err};
+
+fn interop_mlua_isint(_luau: &Lua, n: LuaValue) -> LuaValueResult {
+    match n {
+        LuaValue::Integer(_i) => {
+            Ok(LuaValue::Boolean(true))
+        },
+        LuaValue::Number(_n) => {
+            Ok(LuaValue::Boolean(false))
+        },
+        other => {
+            wrap_err!("interop.mlua.isint(n: number) expected n to be a number, got: {:#?}", other)
+        }
+    }
+}
+
+pub fn create_mlua(luau: &Lua) -> LuaResult<LuaTable> {
+    TableBuilder::create(luau)?
+        .with_function("isint", interop_mlua_isint)?
+        .build_readonly()
+}
+
+pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
+    TableBuilder::create(luau)?
+        .with_value("mlua", create_mlua(luau)?)?
+        .build_readonly()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod std_crypt;
 mod std_testing;
 mod globals;
 mod require;
+mod interop;
 
 use crate::std_io_colors as colors;
 

--- a/src/require.rs
+++ b/src/require.rs
@@ -10,7 +10,7 @@ pub fn require(luau: &Lua, path: LuaValue) -> LuaValueResult {
         }
     };
 
-    if path.starts_with("@std") {
+    if path.starts_with("@std") || path.starts_with("@interop") {
         get_standard_library(luau, path)
     } else {
         let path = resolve_path(luau, path)?;
@@ -114,6 +114,8 @@ fn get_standard_library(luau: &Lua, path: String) -> LuaValueResult {
                 .build_readonly()
             )
         },
+        "@interop" => ok_table(interop::create(luau)),
+        "@interop/mlua" => ok_table(interop::create_mlua(luau)),
         other => {
             wrap_err!("program required an unexpected standard library: {}", other)
         }

--- a/src/scripts/output_process_values.luau
+++ b/src/scripts/output_process_values.luau
@@ -1,0 +1,462 @@
+--!optimize 2
+--!nolint LocalShadow
+--[[
+    doing highly recursive operations + lots of table iteration is faster directly in luau
+    rather than through mlua's interop layer, which, among other things, has additional safety costs
+    associated with iterating through tables
+]]
+
+local mlua = require("@interop/mlua")
+local colors = require("@std/colors")
+local output = require("@std/io/output")
+
+local testvec = (vector.create :: any)(1, 2, 3, 4)
+local s, f = pcall(function()
+    return (testvec :: any).w == 4
+end)
+
+local VECTOR_FOUR_WIDE_MODE = if s then true else false
+
+local function get_table_id(t: { [any]: any }): string
+    if typeof(t) ~= "table" then
+        error("[INTERNAL] output_process_values.get_table_id got passed something that isn't a table")
+    end
+    local tostringed_t = tostring(t)
+    -- remove the `table: ` part of `table: 0x000062524e10a0d8`
+    local tableid = string.sub(tostringed_t, 8, #tostringed_t)
+    return tableid
+end
+
+local IDENTIFIER_PATTERN = "^[%a_][%w_]*$"
+
+local function process_raw_values(
+    value: any,
+    seen_tables: { [string]: string }?,
+    depth: number?
+): string
+    seen_tables = seen_tables or {}
+    local result = ""
+    local depth = depth or 0
+    local current_indent = string.rep("    ", depth)
+    if typeof(value) == "table" then
+        local value = value :: { [any]: any }
+        local table_id = get_table_id(value)
+        local seen_name = seen_tables[table_id]
+        if seen_name then
+            result ..= "cyclic(" .. seen_name .. ")"
+        else
+            if depth == 0 then
+                seen_tables[table_id] = "self" -- so we can recognize top level cyclic tables
+            end
+            result ..= "{\n"
+            for key, val in value do
+                result ..= current_indent
+                result ..= "    "
+                -- handle key stringification
+                if typeof(key) == "string" then
+                    -- we can omit brackets if key is an identifier-like key (like "meow1234" which is vs "cats are cool" which isn't)
+                    if string.match(key, IDENTIFIER_PATTERN) then
+                        result ..= key
+                    else
+                        result ..= "[\"" .. key .. "\"]"
+                    end
+                elseif typeof(key) == "number" then
+                    if mlua.isint(key) then
+                        result ..= "[" .. tostring(key) .. "]"
+                    else -- is a LuaNumber
+                        if math.round(key) == key then
+                            result ..= "[" .. tostring(key) .. ".0]"
+                        else
+                            result ..= "[" .. tostring(key) .. "]"
+                        end
+                    end
+                elseif typeof(key) == "table" then
+                    local key = key :: { [any]: any }
+                    local key_tableid = get_table_id(key)
+                    local seen_key_name = seen_tables[key_tableid]
+                    if seen_key_name then
+                        result ..= "[cyclic(" .. seen_key_name .. ")]"
+                    else
+                        -- according to ariel et al, people probably want to see addresses in debug mode
+                        local stringified_tableid = string.gsub(table_id, "0x0*", "")
+                        result ..= "[table(0x" .. stringified_tableid .. ")]"
+                        -- but pretty print should show full table
+                    end
+                else
+                    result ..= "[" .. process_raw_values(key, seen_tables, depth + 1) .. "]"
+                end
+                result ..= " = "
+                -- handle val stringification
+                if typeof(val) == "table" then
+                    local val = val :: { [any]: any }
+                    local val_tableid = get_table_id(val)
+                    local seen_val_name = seen_tables[val_tableid]
+                    if seen_val_name then
+                        result ..= "cyclic(" .. seen_val_name .. ")"
+                    else
+                        result ..= process_raw_values(val, seen_tables, depth + 1)
+                    end
+                elseif typeof(val) == "string" then -- no need for extra recursive call for common case
+                    result ..= '"' .. val .. '"'
+                else
+                    result ..= process_raw_values(val, seen_tables, depth + 1)
+                end
+                result ..= ",\n"
+            end
+        end
+        result ..= current_indent ..  "}"
+    elseif typeof(value) == "string" then
+        result ..= '"' .. value .. '"'
+    elseif typeof(value) == "boolean" then
+        result ..= tostring(value)
+    elseif typeof(value) == "number" then
+        if mlua.isint(value) then
+            result ..= tostring(value)
+        else
+            if math.round(value) == value then
+                result ..= tostring(value) .. ".0"
+            else
+                result ..= tostring(value)
+            end
+        end
+    elseif typeof(value) == "function" then
+        local function_id = tostring(value)
+        function_id = string.gsub(function_id, "function: 0x0*", "")
+        return "function<0x" .. function_id .. ">"
+    elseif typeof(value) == "buffer" then
+        local buffer_id = tostring(value)
+        buffer_id = string.gsub(buffer_id, "buffer: 0x0*", "")
+        return "buffer<0x" .. buffer_id .. ">"
+    elseif type(value) == "vector" then
+        local vec = "vector<" .. value.x .. ", " .. value.y .. ", " .. value.z
+        if VECTOR_FOUR_WIDE_MODE then
+            vec ..= ", " ..  value.z
+        end
+        vec ..= ">"
+        return vec
+    elseif mlua.iserror(value) then
+        local stringified_error = tostring(value)
+        local errsplit = string.split(stringified_error, "\n")
+        local errmsglist = {}
+        for _, m in errsplit do
+            if string.find(m, "stack traceback") then
+                break
+            else
+                table.insert(errmsglist, m)
+            end
+        end
+        return "error<" .. output.unformat(table.concat(errmsglist)) .. ">"
+    elseif type(value) == "userdata" then
+        local typeof_value = typeof(value)
+        if typeof_value ~= "userdata" then
+            return "userdata<" .. typeof_value .. ">"
+        else
+            local userdata_id = tostring(value)
+            userdata_id = string.gsub(userdata_id, "userdata: 0x0*", "")
+            return "userdata<0x" .. userdata_id .. ">"
+        end
+    elseif type(value) == "nil" then
+        return "nil"
+    elseif type(value) == "thread" then
+        local coro_id = tostring(value)
+        coro_id = string.gsub(coro_id, "thread: 0x0*", "")
+        return "coroutinethread<0x" .. coro_id .. ">"
+    else
+        return tostring(value)
+    end
+    return result
+end
+
+type TablePair = {
+    key: any,
+    val: any,
+}
+
+local function sort_table_pairs(unsorted_pairs: { TablePair }): { TablePair }
+    local sorted_pairs: { TablePair } = table.create(#unsorted_pairs) :: { TablePair }
+    local seen_indices: { [number]: boolean } = {} -- indices seen/visited in unsorted_pairs
+
+    local numerical_pairs: { TablePair } = {} do
+        for index, pair in unsorted_pairs do
+            if type(pair.key) == "number" then
+                seen_indices[index] = true
+                table.insert(numerical_pairs, pair)
+            end
+        end
+        table.sort(numerical_pairs, function(a: TablePair, b: TablePair)
+            local isint_a = mlua.isint(a.key)
+            local isint_b = mlua.isint(b.key)
+            if isint_a and isint_b then
+                return a.key < b.key
+            elseif isint_a and not isint_b then
+                return true
+            elseif isint_b and not isint_a then
+                return false
+            else
+                return a.key < b.key
+            end
+        end)
+    end
+
+    for _, v in numerical_pairs do
+        table.insert(sorted_pairs, v)
+    end
+
+    local string_pairs: { TablePair } = {} do
+        for index, pair in unsorted_pairs do
+            if type(pair.key) == "string" then
+                seen_indices[index] = true
+                table.insert(string_pairs, pair)
+            end
+        end
+        table.sort(string_pairs, function(a: TablePair, b: TablePair)
+            local a_byte, b_byte = string.byte(a.key), string.byte(b.key)
+            return a_byte < b_byte
+        end)
+    end
+
+    for _, v in string_pairs do
+        table.insert(sorted_pairs, v)
+    end
+
+    for index, pair in unsorted_pairs do
+        if not seen_indices[index] then
+            table.insert(sorted_pairs, pair)
+        end
+    end
+
+    return sorted_pairs
+end
+
+local RESET = colors.codes.RESET
+local RED = colors.codes.RED
+local CYAN = colors.codes.CYAN
+local MAGENTA = colors.codes.MAGENTA
+local BLUE = colors.codes.BLUE
+local BOLD_BLUE = colors.codes.BOLD_BLUE
+local GREEN = colors.codes.GREEN
+local YELLOW = colors.codes.YELLOW
+local BLACK = colors.codes.BLACK
+
+local ID_CATCHER_PATTERN = "[.]*0x0*([%d%w]+)"
+
+local function process_pretty_values(
+    value: any,
+    seen_tables: { [{ [any]: any }]: string }?,
+    depth: number?,
+    parent_key: string?
+): string
+    seen_tables = seen_tables or {}
+    local depth = depth or 0
+    if depth > 6 then
+        return "DEPTH EXCEEDED"
+    end
+    local current_indent = string.rep("    ", depth)
+    if type(value) == "table" then
+        local value = value :: { [any]: any }
+        local result = "{\n"
+
+        if depth == 0 then
+            seen_tables[value] = "self" -- track top level cyclic tables
+        end
+
+        -- pretty printed tables should be printed in numerical, then alphabetical order (if possible)
+        local unsorted_pairs: { TablePair } = {}
+        for k, v in value do 
+            table.insert(unsorted_pairs, { key = k, val = v }) 
+        end
+
+        local sorted_pairs: { TablePair } = sort_table_pairs(unsorted_pairs)
+        if #sorted_pairs == 0 then
+            return "{}" -- special case empty tables
+        end
+        for _, pair in sorted_pairs do
+            local key, val = pair.key, pair.val
+            result ..= current_indent .. "    "
+
+            -- stringify keys
+            local key_type = type(key)
+            if key_type == "number" then
+                result ..= "["
+                       .. if mlua.isint(key) then BLUE .. tostring(key) .. RESET
+                          else MAGENTA .. tostring(key) .. RESET
+                result ..= "]" 
+            elseif key_type == "string" then
+                if string.match(key, IDENTIFIER_PATTERN) then
+                    result ..= key
+                else
+                    result ..= `[{GREEN}"{key}"{RESET}]`
+                end
+            elseif key_type == "table" then
+                local seen_name = seen_tables[key]
+                if seen_name then
+                    result ..= "[" .. colors.bold.white(seen_name) .. "]"
+                else
+                    result ..= "[" .. process_pretty_values(key, seen_tables, depth + 1) .. "]"
+                end
+            else
+                result ..= `[{process_pretty_values(key, seen_tables, depth + 1)}]`
+            end
+
+            result ..= " = "
+            -- stringify values
+            if typeof(val) == "table" then
+                if not seen_tables[val] then
+                    seen_tables[val] = tostring(key)
+                end
+                if val == value then
+                    local seen_name = seen_tables[value]
+                    if seen_name then
+                        -- result ..= colors.bold.white(seen_name)
+                        result ..= colors.codes.BOLD_YELLOW .. seen_name .. RESET
+                    else
+                        result ..= "other cyclic"
+                    end
+                else
+                    result ..= process_pretty_values(val, seen_tables, depth + 1)
+                    seen_tables[val] = tostring(key)
+                end
+            else
+                result ..= process_pretty_values(val, seen_tables, depth + 1)
+            end
+            result ..= ",\n"
+        end
+        result ..= current_indent .. "}"
+        -- print(sorted_pairs)
+        return result
+    elseif type(value) == "number" then
+        if not mlua.isint(value) and math.round(value) == value then
+            return BLUE .. tostring(value) .. ".0" .. RESET
+        else
+            return BLUE .. tostring(value) .. RESET
+        end
+    elseif type(value) == "string" then
+        return GREEN .. '"' .. value .. '"' .. RESET
+    elseif type(value) == "boolean" then
+        return YELLOW .. tostring(value) .. RESET
+    elseif type(value) == "vector" then
+        return `{RED}vector<{BOLD_BLUE}{value.x}{CYAN}, {BOLD_BLUE}{value.y}{CYAN}, {BOLD_BLUE}{value.z}{RESET}{RED}>{RESET}`
+    elseif type(value) == "function" then
+        local function_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        local last_five = string.sub(function_id, #function_id - 4, # function_id)
+        local first_part = string.sub(function_id, 1, #function_id - 5)
+        if function_id then
+            return RED .. "function<0x" .. first_part .. colors.bold.red(last_five) .. RESET .. RED .. ">" .. RESET
+        else
+            return RED .. "function" .. RESET
+        end
+    elseif type(value) == "buffer" then
+        local buffer_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        local last_five = string.sub(buffer_id, #buffer_id - 4, # buffer_id)
+        local first_part = string.sub(buffer_id, 1, #buffer_id - 5)
+        if buffer_id then
+            return MAGENTA .. "buffer<0x" .. first_part .. colors.bold.magenta(last_five) .. RESET .. MAGENTA .. ">" .. RESET
+        else
+            return MAGENTA .. "buffer" .. RESET
+        end
+    elseif mlua.iserror(value) then
+        local stringified_error = tostring(value)
+        local errsplit = string.split(stringified_error, "\n")
+        local errmsglist = {}
+        for _, m in errsplit do
+            if string.find(m, "stack traceback") then
+                break
+            else
+                table.insert(errmsglist, m)
+            end
+        end
+        return colors.codes.BOLD_RED .. "error" .. RESET .. RED .. "<" .. table.concat(errmsglist) .. ">" .. RESET
+    elseif type(value) == "thread" then
+        local thread_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        if thread_id then
+            return "corothread<" .. thread_id .. ">"
+        else
+            return "coroutinethread"
+        end
+    elseif type(value) == "userdata" then
+        local typeof_userdata = typeof(value)
+        if typeof_userdata ~= "userdata" then
+            return colors.bold.magenta(typeof_userdata)
+        else
+            local userdata_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+            if userdata_id then
+                return MAGENTA .. "userdata<0x" .. userdata_id .. ">" .. RESET
+            else
+                return MAGENTA .. "userdata" .. RESET
+            end
+        end
+    else
+        return tostring(value)
+    end
+end
+
+-- local meow = {
+--     fed = false,
+--     data = {
+--         ["/opt/idk/2"] = "safe",
+--     },
+--     cats = {
+--         Taz = 1,
+--         Nan = 2,
+--     },
+--     doer = function()
+        
+--     end,
+--     [{ "i am a key" }] = true,
+--     [1.25] = 1,
+--     [vector.create(1, 2, 2312311.23)] = 12,
+-- }
+-- meow.a = meow
+-- meow.cats.newcat = meow.cats
+-- meow.meow = meow.cats.newcat
+-- local buffy = buffer.create(32)
+-- meow.b = buffy
+-- local v = vector.create(0, 12, 2)
+-- meow.v = v
+
+-- local s, r = pcall(function()
+--     local fs = require("@std/fs")
+--     fs.readfile("we are an error. short days ago we were also error")
+-- end)
+
+-- meow.err = r
+-- get_table_id(meow)
+
+-- local user = newproxy()
+
+-- meow.u = user
+
+-- local coro = coroutine.create(function()
+
+-- end)
+
+-- meow.coro = coro
+
+-- local seen_tables = {}
+-- -- print(process_raw_values(meow, seen_tables))
+-- -- print(`print(meow.err): {tostring(meow.err)}`)
+
+-- local prettyvalues = {
+--     a = 1,
+--     [1] = "hi",
+--     [2] = "meow",
+--     [3] = "stasrtawf",
+--     b = "3",
+--     [1.25] = 4,
+--     ["hello world"] = true,
+--     ["emowtsartatf"] = {},
+--     ["/opt/cats/1"] = true,
+--     [buffer.create(12)] = "hi",
+--     location = vector.create(1, 2, 4),
+-- }
+
+-- meow.pretty = prettyvalues
+
+-- local output = require("@std/io/output")
+
+-- output.write(process_pretty_values(meow, {}) .. "\n")
+
+return {
+    simple_print = process_raw_values,
+    pretty_print = process_pretty_values,
+}

--- a/src/scripts/output_process_values.luau
+++ b/src/scripts/output_process_values.luau
@@ -301,19 +301,16 @@ local function process_pretty_values(
             result ..= " = "
             -- stringify values
             if typeof(val) == "table" then
-                if not seen_tables[val] then
-                    seen_tables[val] = tostring(key)
-                end
-                if val == value then
-                    local seen_name = seen_tables[value]
-                    if seen_name then
-                        -- result ..= colors.bold.white(seen_name)
-                        result ..= colors.codes.BOLD_YELLOW .. seen_name .. RESET
-                    else
-                        result ..= "other cyclic"
-                    end
+                local seen_name = seen_tables[val]
+                if seen_name then
+                    result ..= colors.codes.BOLD_YELLOW .. seen_name .. RESET
                 elseif depth + 1 > 6 then
-                    result ..= "{" .. colors.codes.BOLD_WHITE .. "..." .. RESET .. "}"
+                    -- next(val) is nil if the table has no elements
+                    if next(val :: any) == nil then
+                        result ..= "{}"
+                    else
+                        result ..= "{" .. colors.codes.BOLD_WHITE .. "..." .. RESET .. "}"
+                    end
                 else
                     result ..= process_pretty_values(val, seen_tables, depth + 1)
                     seen_tables[val] = tostring(key)

--- a/src/scripts/output_process_values.luau
+++ b/src/scripts/output_process_values.luau
@@ -301,19 +301,20 @@ local function process_pretty_values(
             result ..= " = "
             -- stringify values
             if typeof(val) == "table" then
+                local val = val :: { [any]: any }
+
                 local seen_name = seen_tables[val]
                 if seen_name then
                     result ..= colors.codes.BOLD_YELLOW .. seen_name .. RESET
                 elseif depth + 1 > 6 then
-                    -- next(val) is nil if the table has no elements
-                    if next(val :: any) == nil then
+                    if next(val) == nil then -- table is empty
                         result ..= "{}"
                     else
                         result ..= "{" .. colors.codes.BOLD_WHITE .. "..." .. RESET .. "}"
                     end
                 else
-                    result ..= process_pretty_values(val, seen_tables, depth + 1)
                     seen_tables[val] = tostring(key)
+                    result ..= process_pretty_values(val, seen_tables, depth + 1)
                 end
             else
                 result ..= process_pretty_values(val, seen_tables, depth + 1)
@@ -388,72 +389,6 @@ local function process_pretty_values(
         return tostring(value)
     end
 end
-
--- local meow = {
---     fed = false,
---     data = {
---         ["/opt/idk/2"] = "safe",
---     },
---     cats = {
---         Taz = 1,
---         Nan = 2,
---     },
---     doer = function()
-        
---     end,
---     [{ "i am a key" }] = true,
---     [1.25] = 1,
---     [vector.create(1, 2, 2312311.23)] = 12,
--- }
--- meow.a = meow
--- meow.cats.newcat = meow.cats
--- meow.meow = meow.cats.newcat
--- local buffy = buffer.create(32)
--- meow.b = buffy
--- local v = vector.create(0, 12, 2)
--- meow.v = v
-
--- local s, r = pcall(function()
---     local fs = require("@std/fs")
---     fs.readfile("we are an error. short days ago we were also error")
--- end)
-
--- meow.err = r
--- get_table_id(meow)
-
--- local user = newproxy()
-
--- meow.u = user
-
--- local coro = coroutine.create(function()
-
--- end)
-
--- meow.coro = coro
-
--- local seen_tables = {}
--- -- print(process_raw_values(meow, seen_tables))
--- -- print(`print(meow.err): {tostring(meow.err)}`)
-
--- local prettyvalues = {
---     a = 1,
---     [1] = "hi",
---     [2] = "meow",
---     [3] = "stasrtawf",
---     b = "3",
---     [1.25] = 4,
---     ["hello world"] = true,
---     ["emowtsartatf"] = {},
---     ["/opt/cats/1"] = true,
---     [buffer.create(12)] = "hi",
---     location = vector.create(1, 2, 4),
--- }
-
--- meow.pretty = prettyvalues
-
--- local output = require("@std/io/output")
-
--- output.write(process_pretty_values(meow, {}) .. "\n")
 
 return {
     simple_print = process_raw_values,

--- a/src/scripts/output_process_values.luau
+++ b/src/scripts/output_process_values.luau
@@ -170,48 +170,58 @@ end
 local RESET = colors.codes.RESET
 local BOLD_WHITE = colors.codes.BOLD_WHITE
 local RED = colors.codes.RED
+local BOLD_RED = colors.codes.BOLD_RED
 local CYAN = colors.codes.CYAN
 local MAGENTA = colors.codes.MAGENTA
+local BOLD_MAGENTA = colors.codes.BOLD_MAGENTA
 local BLUE = colors.codes.BLUE
 local BOLD_BLUE = colors.codes.BOLD_BLUE
 local GREEN = colors.codes.GREEN
 local YELLOW = colors.codes.YELLOW
 local BOLD_YELLOW = colors.codes.BOLD_YELLOW
 local BLACK = colors.codes.BLACK
+local BOLD = colors.codes.BOLD
+local DIM = colors.codes.DIM
+
+local LEFT_BRACKET = DIM .. "[" .. RESET
+local RIGHT_BRACKET = DIM .. "]" .. RESET
+
+local LEFT_ANGLED = BOLD .. DIM .. "<" .. RESET
+local RIGHT_ANGLED = BOLD .. DIM .. ">" .. RESET
 
 local ID_CATCHER_PATTERN = "[.]*0x0*([%d%w]+)"
 
 local function stringify_simple_type(value: any): string
     if type(value) == "number" then
-        if not mlua.isint(value) and math.round(value) == value then
-            return BLUE .. tostring(value) .. ".0" .. RESET
-        else
+        -- mlua Numbers are BOLD_BLUE and Integers are regular BLUE
+        if mlua.isint(value) then
             return BLUE .. tostring(value) .. RESET
+        else
+            return BOLD_BLUE .. tostring(value) .. (if math.round(value) == value then ".0" else "") .. RESET
         end
     elseif type(value) == "string" then
         return GREEN .. '"' .. value .. '"' .. RESET
     elseif type(value) == "boolean" then
         return YELLOW .. tostring(value) .. RESET
     elseif type(value) == "vector" then
-        return `{RED}vector<{BOLD_BLUE}{value.x}{CYAN}, {BOLD_BLUE}{value.y}{CYAN}, {BOLD_BLUE}{value.z}{RESET}{RED}>{RESET}`
+        return BOLD_RED .. "vector" .. RESET .. LEFT_ANGLED
+               .. BOLD_BLUE .. value.x .. CYAN .. ", "
+               .. BOLD_BLUE .. value.y .. CYAN .. ", "
+               .. BOLD_BLUE .. value.z .. CYAN ..
+               (if VECTOR_FOUR_WIDE_MODE then ", " ..
+                  BOLD_BLUE .. value.w
+               else "") 
+               .. RED .. RIGHT_ANGLED .. RESET
     elseif type(value) == "function" then
         local function_id = string.match(tostring(value), ID_CATCHER_PATTERN)
         local last_five = string.sub(function_id, #function_id - 4, # function_id)
         local first_part = string.sub(function_id, 1, #function_id - 5)
-        if function_id then
-            return RED .. "function<0x" .. first_part .. colors.bold.red(last_five) .. RESET .. RED .. ">" .. RESET
-        else
-            return RED .. "function" .. RESET
-        end
+        return BOLD_RED .. "function" .. RESET .. LEFT_ANGLED .. RED .. "0x" ..  first_part .. colors.bold.red(last_five) .. RESET .. RED .. RIGHT_ANGLED
     elseif type(value) == "buffer" then
         local buffer_id = string.match(tostring(value), ID_CATCHER_PATTERN)
         local last_five = string.sub(buffer_id, #buffer_id - 4, # buffer_id)
         local first_part = string.sub(buffer_id, 1, #buffer_id - 5)
-        if buffer_id then
-            return MAGENTA .. "buffer<0x" .. first_part .. colors.bold.magenta(last_five) .. RESET .. MAGENTA .. ">" .. RESET
-        else
-            return MAGENTA .. "buffer" .. RESET
-        end
+        return BOLD_MAGENTA .. "buffer" .. RESET .. LEFT_ANGLED .. MAGENTA .. "0x" .. first_part .. colors.bold.magenta(last_five) .. RESET .. MAGENTA .. RIGHT_ANGLED
     elseif mlua.iserror(value) then
         local stringified_error = tostring(value)
         local errsplit = string.split(stringified_error, "\n")
@@ -223,30 +233,26 @@ local function stringify_simple_type(value: any): string
                 table.insert(errmsglist, m)
             end
         end
-        return colors.codes.BOLD_RED .. "error" .. RESET .. RED .. "<" .. table.concat(errmsglist) .. ">" .. RESET
+        return BOLD_RED .. "error" .. RESET .. RED .. LEFT_ANGLED .. table.concat(errmsglist) .. RIGHT_ANGLED
     elseif type(value) == "thread" then
         local thread_id = string.match(tostring(value), ID_CATCHER_PATTERN)
-        if thread_id then
-            return "corothread<" .. thread_id .. ">"
-        else
-            return "coroutinethread"
-        end
+        return "corothread" .. LEFT_ANGLED .. "0x" .. thread_id .. RIGHT_ANGLED
     elseif type(value) == "table" then -- treat a table as a simple value
         local table_id = string.match(tostring(value), ID_CATCHER_PATTERN)
         local last_five = string.sub(table_id, #table_id - 4, # table_id)
         local first_part = string.sub(table_id, 1, #table_id - 5)
-        return "table<0x" .. first_part .. BOLD_WHITE .. last_five .. RESET .. ">"
+        return BOLD_WHITE .. "table" .. RESET .. LEFT_ANGLED .. "0x" .. first_part .. BOLD_WHITE .. last_five .. RESET .. RIGHT_ANGLED
     elseif type(value) == "userdata" then
+        local userdata_id = string.match(tostring(value), ID_CATCHER_PATTERN)
         local typeof_userdata = typeof(value)
-        if typeof_userdata ~= "userdata" then
-            return colors.bold.magenta(typeof_userdata)
-        else
-            local userdata_id = string.match(tostring(value), ID_CATCHER_PATTERN)
-            if userdata_id then
-                return MAGENTA .. "userdata<0x" .. userdata_id .. ">" .. RESET
+        if typeof_userdata ~= "userdata" then -- userdatas with custom names
+            if typeof_userdata ~= "null" and typeof_userdata ~= "undefined" then -- json null & undefined dont need address printed
+                return BOLD_MAGENTA .. typeof_userdata .. RESET .. LEFT_ANGLED .. MAGENTA .. userdata_id .. RESET .. RIGHT_ANGLED
             else
-                return MAGENTA .. "userdata" .. RESET
+                return colors.bold.magenta(typeof_userdata)
             end
+        else
+            return BOLD_MAGENTA .. "userdata" .. RESET .. LEFT_ANGLED .. "0x" .. userdata_id .. RIGHT_ANGLED
         end
     else
         return tostring(value)
@@ -260,13 +266,12 @@ local function stringify_table_path(current_table_path: { any }): string
             if string.match(level, IDENTIFIER_PATTERN) then
                 table_path ..= "." .. level
             else
-                -- table_path ..= "[\"" .. level .. "\"]"
-                table_path ..= "[" .. GREEN .. '"' .. level .. '"' .. RESET .. "]"
+                table_path ..= LEFT_BRACKET .. GREEN .. '"' .. level .. '"' .. RESET .. RIGHT_BRACKET
             end
         elseif typeof(level) == "number" then
-            table_path ..= "[" .. BLUE .. level .. RESET .. "]"
+            table_path ..= LEFT_BRACKET .. BLUE .. level .. RESET .. RIGHT_BRACKET
         else
-            table_path ..= "[" .. stringify_simple_type(level) .. "]"
+            table_path ..= LEFT_BRACKET .. stringify_simple_type(level) .. RIGHT_BRACKET
         end
     end
     return table_path
@@ -371,39 +376,59 @@ local function process_pretty_values(
             -- stringify keys
             local key_type = type(key)
             if key_type == "number" then
-                result ..= "["
+                -- left pad array keys by prepending spaces in front of [
+                -- so the = signs are aligned
+                if #value > 10 and #value < 100 then
+                    if key < 10 then
+                        result ..= " "
+                    end
+                elseif #value > 100 and #value < 1000 then
+                    if key < 10 then
+                        result ..= "  "
+                    elseif key < 100 then
+                        result ..= " "
+                    end
+                elseif #value > 1000 then
+                    if key < 10 then
+                        result ..= "   "
+                    elseif key < 100 then
+                        result ..= "  "
+                    elseif key < 1000 then
+                        result ..= " "
+                    end
+                end
+                result ..= LEFT_BRACKET
                        .. if mlua.isint(key) then BLUE .. tostring(key) .. RESET
-                          else MAGENTA .. tostring(key) .. RESET
-                result ..= "]" 
+                          else BOLD_BLUE .. tostring(key) .. RESET
+                result ..= RIGHT_BRACKET
             elseif key_type == "string" then
                 if string.match(key, IDENTIFIER_PATTERN) then
                     result ..= key
                 else
-                    result ..= `[{GREEN}"{key}"{RESET}]`
+                    result ..= LEFT_BRACKET .. GREEN .. '"' .. key .. '"' .. RESET .. RIGHT_BRACKET
                 end
             elseif key_type == "table" then
                 local seen_name = seen_tables[key]
                 if seen_name then
-                    result ..= "[" .. seen_name .. "]"
+                    result ..= LEFT_BRACKET .. seen_name .. RIGHT_BRACKET
                 elseif depth + 1 > 6 then
                     local tableid = string.match(tostring(key), ID_CATCHER_PATTERN)
-                    result ..= "[" .. colors.cyan(`table<0x{tableid}>`) .. "]"
+                    result ..= LEFT_BRACKET .. colors.cyan(`table<0x{tableid}>`) .. RIGHT_BRACKET
                 else
-                    result ..= "[" .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. "]"
+                    result ..= LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. RIGHT_BRACKET
                 end
             else
-                result ..= `[{process_pretty_values(key, seen_tables, depth + 1, current_table_path)}]`
+                result ..= LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. RIGHT_BRACKET
             end
 
             result ..= " = "
 
             -- stringify values
-            if typeof(val) == "table" then
+            if type(val) == "table" then
                 local val = val :: { [any]: any }
                 local seen_name = seen_tables[val]
                 if seen_name then
                     result ..= seen_name
-                    -- result ..= colors.codes.BOLD_YELLOW .. seen_name .. RESET
                 elseif depth + 1 > 6 then
                     if next(val) == nil then -- table is empty
                         result ..= "{}"
@@ -418,14 +443,28 @@ local function process_pretty_values(
                     -- pop key from current_table_path after recursion
                     table.remove(current_table_path, #current_table_path)
                 end
+            elseif type(val) == "string" then -- don't recurse in extremely common case
+                if string.find(val, "\n") then
+                    if #val < 42 then
+                        result ..= GREEN .. '"' .. string.gsub(val, "\n", "\\n") .. '"' .. RESET
+                    else
+                        result ..= "(newlined string starts on next line) " ..  GREEN .. "\n" .. val .. RESET .. "\n(end newlined string)"
+                    end
+                else
+                    result ..= GREEN .. '"' .. val .. '"' .. RESET
+                end
+            elseif type(val) == "number" or type(val) == "boolean" then
+                result ..= stringify_simple_type(val)
             else
                 result ..= process_pretty_values(val, seen_tables, depth + 1, current_table_path)
             end
             
-            result ..= ",\n"
+            result ..= DIM .. "," .. RESET .. "\n"
         end
         result ..= current_indent .. "}"
         return result
+    elseif type(value) == "string" and depth == 0 then -- calling print("hello world") shouldn't colorize
+        return value
     else
         return stringify_simple_type(value)
     end

--- a/src/scripts/output_process_values.luau
+++ b/src/scripts/output_process_values.luau
@@ -167,6 +167,111 @@ local function process_raw_values(
     return result
 end
 
+local RESET = colors.codes.RESET
+local BOLD_WHITE = colors.codes.BOLD_WHITE
+local RED = colors.codes.RED
+local CYAN = colors.codes.CYAN
+local MAGENTA = colors.codes.MAGENTA
+local BLUE = colors.codes.BLUE
+local BOLD_BLUE = colors.codes.BOLD_BLUE
+local GREEN = colors.codes.GREEN
+local YELLOW = colors.codes.YELLOW
+local BOLD_YELLOW = colors.codes.BOLD_YELLOW
+local BLACK = colors.codes.BLACK
+
+local ID_CATCHER_PATTERN = "[.]*0x0*([%d%w]+)"
+
+local function stringify_simple_type(value: any): string
+    if type(value) == "number" then
+        if not mlua.isint(value) and math.round(value) == value then
+            return BLUE .. tostring(value) .. ".0" .. RESET
+        else
+            return BLUE .. tostring(value) .. RESET
+        end
+    elseif type(value) == "string" then
+        return GREEN .. '"' .. value .. '"' .. RESET
+    elseif type(value) == "boolean" then
+        return YELLOW .. tostring(value) .. RESET
+    elseif type(value) == "vector" then
+        return `{RED}vector<{BOLD_BLUE}{value.x}{CYAN}, {BOLD_BLUE}{value.y}{CYAN}, {BOLD_BLUE}{value.z}{RESET}{RED}>{RESET}`
+    elseif type(value) == "function" then
+        local function_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        local last_five = string.sub(function_id, #function_id - 4, # function_id)
+        local first_part = string.sub(function_id, 1, #function_id - 5)
+        if function_id then
+            return RED .. "function<0x" .. first_part .. colors.bold.red(last_five) .. RESET .. RED .. ">" .. RESET
+        else
+            return RED .. "function" .. RESET
+        end
+    elseif type(value) == "buffer" then
+        local buffer_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        local last_five = string.sub(buffer_id, #buffer_id - 4, # buffer_id)
+        local first_part = string.sub(buffer_id, 1, #buffer_id - 5)
+        if buffer_id then
+            return MAGENTA .. "buffer<0x" .. first_part .. colors.bold.magenta(last_five) .. RESET .. MAGENTA .. ">" .. RESET
+        else
+            return MAGENTA .. "buffer" .. RESET
+        end
+    elseif mlua.iserror(value) then
+        local stringified_error = tostring(value)
+        local errsplit = string.split(stringified_error, "\n")
+        local errmsglist = {}
+        for _, m in errsplit do
+            if string.find(m, "stack traceback") then
+                break
+            else
+                table.insert(errmsglist, m)
+            end
+        end
+        return colors.codes.BOLD_RED .. "error" .. RESET .. RED .. "<" .. table.concat(errmsglist) .. ">" .. RESET
+    elseif type(value) == "thread" then
+        local thread_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        if thread_id then
+            return "corothread<" .. thread_id .. ">"
+        else
+            return "coroutinethread"
+        end
+    elseif type(value) == "table" then -- treat a table as a simple value
+        local table_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        local last_five = string.sub(table_id, #table_id - 4, # table_id)
+        local first_part = string.sub(table_id, 1, #table_id - 5)
+        return "table<0x" .. first_part .. BOLD_WHITE .. last_five .. RESET .. ">"
+    elseif type(value) == "userdata" then
+        local typeof_userdata = typeof(value)
+        if typeof_userdata ~= "userdata" then
+            return colors.bold.magenta(typeof_userdata)
+        else
+            local userdata_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+            if userdata_id then
+                return MAGENTA .. "userdata<0x" .. userdata_id .. ">" .. RESET
+            else
+                return MAGENTA .. "userdata" .. RESET
+            end
+        end
+    else
+        return tostring(value)
+    end
+end
+
+local function stringify_table_path(current_table_path: { any }): string
+    local table_path = BOLD_YELLOW .. "self" .. RESET
+    for _, level in current_table_path do
+        if typeof(level) == "string" then
+            if string.match(level, IDENTIFIER_PATTERN) then
+                table_path ..= "." .. level
+            else
+                -- table_path ..= "[\"" .. level .. "\"]"
+                table_path ..= "[" .. GREEN .. '"' .. level .. '"' .. RESET .. "]"
+            end
+        elseif typeof(level) == "number" then
+            table_path ..= "[" .. BLUE .. level .. RESET .. "]"
+        else
+            table_path ..= "[" .. stringify_simple_type(level) .. "]"
+        end
+    end
+    return table_path
+end
+
 type TablePair = {
     key: any,
     val: any,
@@ -228,33 +333,24 @@ local function sort_table_pairs(unsorted_pairs: { TablePair }): { TablePair }
     return sorted_pairs
 end
 
-local RESET = colors.codes.RESET
-local RED = colors.codes.RED
-local CYAN = colors.codes.CYAN
-local MAGENTA = colors.codes.MAGENTA
-local BLUE = colors.codes.BLUE
-local BOLD_BLUE = colors.codes.BOLD_BLUE
-local GREEN = colors.codes.GREEN
-local YELLOW = colors.codes.YELLOW
-local BLACK = colors.codes.BLACK
-
-local ID_CATCHER_PATTERN = "[.]*0x0*([%d%w]+)"
-
 local function process_pretty_values(
     value: any,
+    -- seen_tables' keys are tables since they get uniquely hashed, value is stringified path
+    -- seen_tables' values should be string? (optional) but that causes inference to fail to complete
     seen_tables: { [{ [any]: any }]: string }?,
     depth: number?,
-    parent_key: string?
+    current_table_path: { any }? -- used to put table paths in seen_tables
 ): string
     seen_tables = seen_tables or {}
     local depth = depth or 0
+    local current_table_path: { any } = current_table_path or {}
     local current_indent = string.rep("    ", depth)
     if type(value) == "table" then
         local value = value :: { [any]: any }
         local result = "{\n"
 
         if depth == 0 then
-            seen_tables[value] = "self" -- track top level cyclic tables
+            seen_tables[value] = BOLD_YELLOW .. "self" .. RESET -- track top level cyclic tables
         end
 
         -- pretty printed tables should be printed in numerical, then alphabetical order (if possible)
@@ -267,6 +363,7 @@ local function process_pretty_values(
         if #sorted_pairs == 0 then
             return "{}" -- special case empty tables
         end
+
         for _, pair in sorted_pairs do
             local key, val = pair.key, pair.val
             result ..= current_indent .. "    "
@@ -287,25 +384,26 @@ local function process_pretty_values(
             elseif key_type == "table" then
                 local seen_name = seen_tables[key]
                 if seen_name then
-                    result ..= "[" .. colors.bold.white(seen_name) .. "]"
+                    result ..= "[" .. seen_name .. "]"
                 elseif depth + 1 > 6 then
                     local tableid = string.match(tostring(key), ID_CATCHER_PATTERN)
                     result ..= "[" .. colors.cyan(`table<0x{tableid}>`) .. "]"
                 else
-                    result ..= "[" .. process_pretty_values(key, seen_tables, depth + 1) .. "]"
+                    result ..= "[" .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. "]"
                 end
             else
-                result ..= `[{process_pretty_values(key, seen_tables, depth + 1)}]`
+                result ..= `[{process_pretty_values(key, seen_tables, depth + 1, current_table_path)}]`
             end
 
             result ..= " = "
+
             -- stringify values
             if typeof(val) == "table" then
                 local val = val :: { [any]: any }
-
                 local seen_name = seen_tables[val]
                 if seen_name then
-                    result ..= colors.codes.BOLD_YELLOW .. seen_name .. RESET
+                    result ..= seen_name
+                    -- result ..= colors.codes.BOLD_YELLOW .. seen_name .. RESET
                 elseif depth + 1 > 6 then
                     if next(val) == nil then -- table is empty
                         result ..= "{}"
@@ -313,80 +411,23 @@ local function process_pretty_values(
                         result ..= "{" .. colors.codes.BOLD_WHITE .. "..." .. RESET .. "}"
                     end
                 else
-                    seen_tables[val] = tostring(key)
-                    result ..= process_pretty_values(val, seen_tables, depth + 1)
+                    -- push key to current_table_path before recursion
+                    table.insert(current_table_path, key)
+                    seen_tables[val] = stringify_table_path(current_table_path) -- tostring(key)
+                    result ..= process_pretty_values(val, seen_tables, depth + 1, current_table_path)
+                    -- pop key from current_table_path after recursion
+                    table.remove(current_table_path, #current_table_path)
                 end
             else
-                result ..= process_pretty_values(val, seen_tables, depth + 1)
+                result ..= process_pretty_values(val, seen_tables, depth + 1, current_table_path)
             end
+            
             result ..= ",\n"
         end
         result ..= current_indent .. "}"
-        -- print(sorted_pairs)
         return result
-    elseif type(value) == "number" then
-        if not mlua.isint(value) and math.round(value) == value then
-            return BLUE .. tostring(value) .. ".0" .. RESET
-        else
-            return BLUE .. tostring(value) .. RESET
-        end
-    elseif type(value) == "string" then
-        return GREEN .. '"' .. value .. '"' .. RESET
-    elseif type(value) == "boolean" then
-        return YELLOW .. tostring(value) .. RESET
-    elseif type(value) == "vector" then
-        return `{RED}vector<{BOLD_BLUE}{value.x}{CYAN}, {BOLD_BLUE}{value.y}{CYAN}, {BOLD_BLUE}{value.z}{RESET}{RED}>{RESET}`
-    elseif type(value) == "function" then
-        local function_id = string.match(tostring(value), ID_CATCHER_PATTERN)
-        local last_five = string.sub(function_id, #function_id - 4, # function_id)
-        local first_part = string.sub(function_id, 1, #function_id - 5)
-        if function_id then
-            return RED .. "function<0x" .. first_part .. colors.bold.red(last_five) .. RESET .. RED .. ">" .. RESET
-        else
-            return RED .. "function" .. RESET
-        end
-    elseif type(value) == "buffer" then
-        local buffer_id = string.match(tostring(value), ID_CATCHER_PATTERN)
-        local last_five = string.sub(buffer_id, #buffer_id - 4, # buffer_id)
-        local first_part = string.sub(buffer_id, 1, #buffer_id - 5)
-        if buffer_id then
-            return MAGENTA .. "buffer<0x" .. first_part .. colors.bold.magenta(last_five) .. RESET .. MAGENTA .. ">" .. RESET
-        else
-            return MAGENTA .. "buffer" .. RESET
-        end
-    elseif mlua.iserror(value) then
-        local stringified_error = tostring(value)
-        local errsplit = string.split(stringified_error, "\n")
-        local errmsglist = {}
-        for _, m in errsplit do
-            if string.find(m, "stack traceback") then
-                break
-            else
-                table.insert(errmsglist, m)
-            end
-        end
-        return colors.codes.BOLD_RED .. "error" .. RESET .. RED .. "<" .. table.concat(errmsglist) .. ">" .. RESET
-    elseif type(value) == "thread" then
-        local thread_id = string.match(tostring(value), ID_CATCHER_PATTERN)
-        if thread_id then
-            return "corothread<" .. thread_id .. ">"
-        else
-            return "coroutinethread"
-        end
-    elseif type(value) == "userdata" then
-        local typeof_userdata = typeof(value)
-        if typeof_userdata ~= "userdata" then
-            return colors.bold.magenta(typeof_userdata)
-        else
-            local userdata_id = string.match(tostring(value), ID_CATCHER_PATTERN)
-            if userdata_id then
-                return MAGENTA .. "userdata<0x" .. userdata_id .. ">" .. RESET
-            else
-                return MAGENTA .. "userdata" .. RESET
-            end
-        end
     else
-        return tostring(value)
+        return stringify_simple_type(value)
     end
 end
 

--- a/src/scripts/output_process_values.luau
+++ b/src/scripts/output_process_values.luau
@@ -248,9 +248,6 @@ local function process_pretty_values(
 ): string
     seen_tables = seen_tables or {}
     local depth = depth or 0
-    if depth > 6 then
-        return "DEPTH EXCEEDED"
-    end
     local current_indent = string.rep("    ", depth)
     if type(value) == "table" then
         local value = value :: { [any]: any }
@@ -291,6 +288,9 @@ local function process_pretty_values(
                 local seen_name = seen_tables[key]
                 if seen_name then
                     result ..= "[" .. colors.bold.white(seen_name) .. "]"
+                elseif depth + 1 > 6 then
+                    local tableid = string.match(tostring(key), ID_CATCHER_PATTERN)
+                    result ..= "[" .. colors.cyan(`table<0x{tableid}>`) .. "]"
                 else
                     result ..= "[" .. process_pretty_values(key, seen_tables, depth + 1) .. "]"
                 end
@@ -312,6 +312,8 @@ local function process_pretty_values(
                     else
                         result ..= "other cyclic"
                     end
+                elseif depth + 1 > 6 then
+                    result ..= "{" .. colors.codes.BOLD_WHITE .. "..." .. RESET .. "}"
                 else
                     result ..= process_pretty_values(val, seen_tables, depth + 1)
                     seen_tables[val] = tostring(key)

--- a/src/scripts/seal_setup_settings.luau
+++ b/src/scripts/seal_setup_settings.luau
@@ -23,6 +23,7 @@ local default_luaurc = {
 	languageMode = "strict",
 	aliases = {
 		std = `.{sep}.typedefs{sep}std{sep}`,
+		interop = `.{sep}.typedefs{sep}interop{sep}`,
 	} :: { [string]: string }
 }
 

--- a/src/std_io_colors.rs
+++ b/src/std_io_colors.rs
@@ -49,10 +49,13 @@ pub const BRIGHT_MAGENTA_BG: &str = "\x1b[105m";
 pub const BRIGHT_CYAN_BG: &str = "\x1b[106m";
 pub const BRIGHT_WHITE_BG: &str = "\x1b[107m";
 
+pub const BOLD: &str = "\x1b[1m";
+pub const DIM: &str = "\x1b[2m";
+
 type LuaValueResult = LuaResult<LuaValue>;
 
 fn colorize(luau: &Lua, text: String, color_code: &str) -> LuaValueResult {
-    let colored_text = format!("{}{}{}", color_code, text, RESET);
+    let colored_text = color_code.to_string() + &text + RESET;
     Ok(LuaValue::String(luau.create_string(&colored_text)?))
 }
 
@@ -88,7 +91,6 @@ fn colorize_white(luau: &Lua, text: String) -> LuaValueResult {
     colorize(luau, text, WHITE)
 }
 
-
 fn colorize_bold_black(luau: &Lua, text: String) -> LuaValueResult {
     colorize(luau, text, BOLD_BLACK)
 }
@@ -121,6 +123,14 @@ fn colorize_bold_white(luau: &Lua, text: String) -> LuaValueResult {
     colorize(luau, text, BOLD_WHITE)
 }
 
+fn style_bold(luau: &Lua, text: String) -> LuaValueResult {
+    colorize(luau, text, BOLD)
+}
+
+fn style_dim(luau: &Lua, text: String) -> LuaValueResult {
+    colorize(luau, text, DIM)
+}
+
 pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
     let bold_colors = TableBuilder::create(luau)?
         .with_function("black", colorize_bold_black)?
@@ -131,6 +141,11 @@ pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
         .with_function("magenta", colorize_bold_magenta)?
         .with_function("cyan", colorize_bold_cyan)?
         .with_function("white", colorize_bold_white)?
+        .build_readonly()?;
+
+    let styles = TableBuilder::create(luau)?
+        .with_function("bold", style_bold)?
+        .with_function("dim", style_dim)?
         .build_readonly()?;
 
     let codes = TableBuilder::create(luau)?
@@ -175,6 +190,8 @@ pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
         .with_value("BRIGHT_MAGENTA_BG", BRIGHT_MAGENTA_BG)?
         .with_value("BRIGHT_CYAN_BG", BRIGHT_CYAN_BG)?
         .with_value("BRIGHT_WHITE_BG", BRIGHT_WHITE_BG)?
+        .with_value("BOLD", BOLD)?
+        .with_value("DIM", DIM)?
         .build_readonly()?;
 
     TableBuilder::create(luau)?
@@ -187,6 +204,7 @@ pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
         .with_function("cyan", colorize_cyan)?
         .with_function("white", colorize_white)?
         .with_value("bold", bold_colors)?
+        .with_value("style", styles)?
         .with_value("codes", codes)?
         .build_readonly()
 }

--- a/src/std_io_output.rs
+++ b/src/std_io_output.rs
@@ -195,11 +195,12 @@ pub fn strip_newlines_and_colors(input: &str) -> String {
 
 fn output_unformat(luau: &Lua, value: LuaValue) -> LuaValueResult {
     let input = match value {
-        LuaValue::String(i) => i.to_string_lossy(),
+        LuaValue::String(s) => s.to_string_lossy(),
         other => {
             return wrap_err!("expected string to strip formatting of, got: {:#?}", other)
         }
     };
+    let input = strip_newlines_and_colors(&input);
     Ok(LuaValue::String(
         luau.create_string(input.as_str())?
     ))

--- a/tests/luau/globals/output.luau
+++ b/tests/luau/globals/output.luau
@@ -99,3 +99,23 @@ local nested_tables = {
 }
 
 print(nested_tables)
+
+print("hi")
+
+print({ a=  "we", "are", "seal"})
+
+print(vector.create(1, 2, 3))
+
+local array_with_many_values = {}; for i = 1, 1001 do table.insert(array_with_many_values, i) end
+-- print(array_with_many_values)
+
+local fs = require("@std/fs")
+
+local src = fs.readfile("./src/error_handling.rs")
+
+local with_newline_strings = {
+	"tafwtfatfwtfwaw\n2321tsartfwat hrsdasrad \n \n 22312",
+	cats = "nanuk\nTaz",
+	src = src,
+}
+print(with_newline_strings)

--- a/tests/luau/globals/output.luau
+++ b/tests/luau/globals/output.luau
@@ -1,3 +1,11 @@
 
-local a = {"2", "3", 4, { a = 3, b = 3.02 }}
+local a = {"2", "3", 4, { a = 3, b = 3.02 }, happy = false}
 print(a)
+
+local b = {
+	happy = true,
+}
+
+b.b = b
+
+print(b)

--- a/tests/luau/globals/output.luau
+++ b/tests/luau/globals/output.luau
@@ -1,19 +1,85 @@
+local meow = {
+    fed = false,
+    data = {
+        ["/opt/idk/2"] = "safe",
+    },
+    cats = {
+        Taz = 1,
+        Nan = 2,
+    },
+    doer = function()
+        
+    end,
+    [{ "i am a key" }] = true,
+    [1.25] = 1,
+    [vector.create(1, 2, 2312311.23)] = 12,
+}
+meow.a = meow
+meow.cats.newcat = meow.cats
+meow.meow = meow.cats.newcat
+local buffy = buffer.create(32)
+meow.b = buffy
+local v = vector.create(0, 12, 2)
+meow.v = v
 
-local a = {"2", "3", 4, { a = 3, b = 3.02 }, happy = false}
-print(a)
+local s, r = pcall(function()
+    local fs = require("@std/fs")
+    fs.readfile("we are an error. short days ago we were also error")
+end)
 
-local b = {
-	happy = true,
+meow.err = r
+
+local user = newproxy()
+
+meow.u = user
+
+local coro = coroutine.create(function()
+
+end)
+
+meow.coro = coro
+
+local seen_tables = {}
+-- print(process_raw_values(meow, seen_tables))
+-- print(`print(meow.err): {tostring(meow.err)}`)
+
+local prettyvalues = {
+    a = 1,
+    [1] = "hi",
+    [2] = "meow",
+    [3] = "stasrtawf",
+    b = "3",
+    [1.25] = 4,
+    ["hello world"] = true,
+    ["emowtsartatf"] = {},
+    ["/opt/cats/1"] = true,
+    [buffer.create(12)] = "hi",
+    location = vector.create(1, 2, 4),
 }
 
-b.b = b
+meow.pretty = prettyvalues
 
-print(b)
+print(prettyvalues)
 
-local fs = require("@std/fs")
-local s, f = pcall(function()
-	return fs.readfile("./startaftatafrst.")
-end)
-p(f)
+local a = {}
+a.b = { [a] = a }
+print(a)
 
-print(package)
+local cats = {}
+cats.Taz = {
+  name = "Taz",
+  age = 12,
+}
+
+cats.Nan = {
+  name = "Nanuk",
+  age = 1,
+}
+
+cats.catlist = {
+  cats.Taz, cats.Nan
+}
+
+cats.self = cats
+
+print(cats)

--- a/tests/luau/globals/output.luau
+++ b/tests/luau/globals/output.luau
@@ -59,7 +59,7 @@ local prettyvalues = {
 
 meow.pretty = prettyvalues
 
-print(prettyvalues)
+print(meow)
 
 local a = {}
 a.b = { [a] = a }
@@ -83,3 +83,19 @@ cats.catlist = {
 cats.self = cats
 
 print(cats)
+
+local children = {
+	["folders 2"] = {
+		{
+			parts = {}
+		}
+	}
+}
+
+local nested_tables = {
+	children = children,
+	parts = children["folders 2"][1].parts,
+	folders = children["folders 2"],
+}
+
+print(nested_tables)

--- a/tests/luau/globals/output.luau
+++ b/tests/luau/globals/output.luau
@@ -9,3 +9,9 @@ local b = {
 b.b = b
 
 print(b)
+
+local fs = require("@std/fs")
+local s, f = pcall(function()
+	return fs.readfile("./startaftatafrst.")
+end)
+p(f)

--- a/tests/luau/globals/output.luau
+++ b/tests/luau/globals/output.luau
@@ -15,3 +15,5 @@ local s, f = pcall(function()
 	return fs.readfile("./startaftatafrst.")
 end)
 p(f)
+
+print(package)

--- a/tests/luau/interop/mlua.luau
+++ b/tests/luau/interop/mlua.luau
@@ -1,0 +1,15 @@
+local mlua = require("@interop/mlua")
+
+local i = 1200
+local f = 1200.01
+local bignumber = 1231231231234445
+
+assert(mlua.isint(i) == true, "int is int")
+assert(mlua.isint(f) == false, "number is false")
+assert(mlua.isint(bignumber) == false, "big integer number actually represented as LuaNumber not LuaInt")
+
+local success, result = pcall(function()
+	return mlua.isint("hello world" :: any)
+end)
+
+assert(success == false, "interop.mlua.isint isnt erroring on invalid input?")

--- a/tests/luau/interop/mlua.luau
+++ b/tests/luau/interop/mlua.luau
@@ -13,3 +13,5 @@ local success, result = pcall(function()
 end)
 
 assert(success == false, "interop.mlua.isint isnt erroring on invalid input?")
+
+assert(mlua.iserror(result) == true, "mlua error is made of error")

--- a/tests/luau/std/io/output.luau
+++ b/tests/luau/std/io/output.luau
@@ -28,3 +28,5 @@ output.ewrite("bye")
 output.write("stasrtfwa")
 
 output.clear()
+
+output.sprint("hi")


### PR DESCRIPTION
- Vast improvements to print (pretty print) 
- pretty printed tables now print in alphabetical order, correctly handle cyclics (with nice aliases relative to `self` (the top level table)), pretty printed vectors, functions, buffers, etc., now get special coloring for readability.
- mlua Integers are BLUE and mlua Numbers are BOLD_BLUE since there's a subtle but important distinction between them
- pretty printed array-like-tables get their indices left-padded to align their equals signs and values
- pretty printed long strings w/ newlines are put onto the next line and clearly delineated with "(newlined string starts on next line)"/"(end newlined string)" tags 
- `@std/colors` gets styles "dim" and "bold", both as functions and `color.codes`
- p changed from debug print to simple print in case all that pretty is too much

