### PR TITLE
Use mluau instead of mlua in seal for improved Luau focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "mlua"
 version = "0.11.0-beta.2"
-source = "git+https://github.com/mlua-rs/mlua.git#63e7cfd31bcea15cf224f55c1213577b6226769a"
+source = "git+https://github.com/mluau/mluau.git#d49ec0882b712024e384e981027a9d4fb138b1c1"
 dependencies = [
  "bstr",
  "either",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "mlua-sys"
 version = "0.8.0"
-source = "git+https://github.com/mlua-rs/mlua.git#63e7cfd31bcea15cf224f55c1213577b6226769a"
+source = "git+https://github.com/mluau/mluau.git#d49ec0882b712024e384e981027a9d4fb138b1c1"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 # If this breaks we'll pin to a commit and risk lagging behind Luau
 # but mlua's main branch is relatively stable and hasn't broken for us before nor for other projects.
 # we need to enable error-send so we can propogate errors across threads in std_thread.rs
-mlua = { git = "https://github.com/mlua-rs/mlua.git", features = ["luau", "serialize", "error-send"] }
+mlua = { git = "https://github.com/mluau/mluau.git", features = ["luau", "serialize", "error-send"] }
 chrono = "0.4.38"
 regex = "1.11.1"
 # needed for seal setup (really useful!)


### PR DESCRIPTION
Switches seal to use mluau instead of mlua.

Fixes #62 