### PR TITLE
Start @std/luau library with eval and bytecode functions

### DIFF
--- a/.seal/typedefs/std/init.luau
+++ b/.seal/typedefs/std/init.luau
@@ -14,7 +14,8 @@ local std = {
 	serde = require("@std/serde"),
 	json = require("@std/json"),
 	net = require("@std/net"),
-	thread = require("@std/thread")
+	thread = require("@std/thread"),
+	luau = require("@std/luau"),
 }
 
 return std

--- a/.seal/typedefs/std/luau/init.luau
+++ b/.seal/typedefs/std/luau/init.luau
@@ -1,0 +1,67 @@
+export type EvalOptions = {
+    name: string?,
+    stdlib: ("seal" | "safe" | "none")?,
+}
+
+export type luau = {
+    --> luau.eval(src: string, options: EvalOptions?)
+    --[=[
+        Evaluate Luau source code from a string in the current Luau VM.
+
+        By default, this function evaluates in `"safe"` mode with only Luau's standard library (minus some deprecated environment breaking functions).
+
+        ### `EvalOptions` options:
+
+        `name` represents the `chunk_name` of the evaluated src.
+
+        `stdlib` can be one of the following (or left unspecified, in which it defaults to `"safe"`):
+
+        - `"safe"` - The evaled code will have access to most libraries/functions that come with Luau, 
+            but nothing that can access your file system or the internet.
+        - `"seal"` - The evaled code will have access to anything seal can do, from accessing environment variables to creating an infinite number of empty files in your home directory.
+        - `"none"` - Disable every single global Luau comes with, including `tostring` and `print`.
+
+        ## Returns
+
+        Either whatever the source code evaluates to (`unknown`), or a tostringable userdata instance representing
+        an error that occurred when evaluating the code, such as a syntax error or runtime error.
+
+        ## Errors
+        - if the code cannot be evaluated, but not if it contains a syntax error or errors at runtime.
+
+        ## Usage
+
+        ```luau
+        local luau = require("@std/luau")
+        local src = [[return { meow = 2 }]]
+        local res = luau.eval(src)
+        local data: { meow: number } = {}
+        if typeof(res) == "error" then
+            print(`error running code: {res}`)
+        else
+            data.meow = (res :: any).meow
+        end
+        ```
+    ]=]
+    eval: (src: string, options: EvalOptions?) -> unknown | error,
+    --> luau.eval_unsafe(src: string | buffer, options: EvalOptions?)
+    --[=[
+        Same as `luau.eval`, except can also accept bytecode as a string or buffer.
+
+        ## ⚠️ Safety
+
+        This function is unsafe. You are responsible for **passing valid Luau bytecode**, and therefore
+        you should trust or check the bytecode you pass to this function.
+
+        If you pass invalid bytecode as `src`, seal will 💥 ***crash*** 💥 from an ***illegal hardware instruction***
+        and *coredump*.
+    ]=]
+    eval_unsafe: (src: string | buffer, options: EvalOptions?) -> unknown | error,
+    --> luau.bytecode(src: string)
+    --[=[
+        Compiles `src` to Luau bytecode.
+    ]=]
+    bytecode: (src: string) -> buffer | error,
+}
+
+return {} :: luau

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -14,7 +14,7 @@ pub fn warn(luau: &Lua, warn_value: LuaValue) -> LuaValueResult {
 
 pub const SEAL_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub fn set_globals(luau: &Lua, entry_path: String) -> LuaValueResult {
+pub fn set_globals<S: AsRef<str>>(luau: &Lua, entry_path: S) -> LuaValueResult {
     let globals: LuaTable = luau.globals();
     // must use globals().get instead of globals().raw_get due to safeenv/sandbox (which requires newindex); raw_get incorrectly returns nil when safeenv enabled
     let luau_version: LuaString = globals.get("_VERSION")?;
@@ -29,7 +29,7 @@ pub fn set_globals(luau: &Lua, entry_path: String) -> LuaValueResult {
     globals.raw_set("_G", TableBuilder::create(luau)?.build()?)?;
     globals.raw_set("_REQUIRE_CACHE", TableBuilder::create(luau)?.build()?)?;
     globals.raw_set("script", TableBuilder::create(luau)?
-        .with_value("entry_path", entry_path)?
+        .with_value("entry_path", entry_path.as_ref())?
         .with_function("path", get_script_path)?
         .with_function("parent", get_script_parent)?
         .build_readonly()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod std_net;
 mod std_serde;
 mod std_str_internal;
 mod std_thread;
+mod std_luau;
 mod sealconfig;
 
 use err::display_error_and_exit;
@@ -261,7 +262,7 @@ fn seal_setup() -> LuauLoadResult {
 
     let seal_setup_settings = include_str!("./scripts/seal_setup_settings.luau");
     let temp_luau = Lua::new();
-    globals::set_globals(&temp_luau, cwd.to_string_lossy().into_owned())?;
+    globals::set_globals(&temp_luau, cwd.to_string_lossy())?;
     match temp_luau.load(seal_setup_settings).exec() {
         Ok(_) => Ok(None),
         Err(err) => {

--- a/src/require/mod.rs
+++ b/src/require/mod.rs
@@ -91,6 +91,8 @@ fn get_standard_library(luau: &Lua, path: String) -> LuaValueResult {
 
         "@std/thread" => ok_table(std_thread::create(luau)),
 
+        "@std/luau" => ok_table(std_luau::create(luau)),
+
         "@std" => {
             ok_table(TableBuilder::create(luau)?
                 .with_value("fs", std_fs::create(luau)?)?

--- a/src/require/mod.rs
+++ b/src/require/mod.rs
@@ -109,6 +109,7 @@ fn get_standard_library(luau: &Lua, path: String) -> LuaValueResult {
                 .with_value("net", std_net::create(luau)?)?
                 .with_value("crypt", std_crypt::create(luau)?)?
                 .with_value("thread", std_thread::create(luau)?)?
+                .with_value("luau", std_luau::create(luau)?)?
                 .build_readonly()
             )
         },

--- a/src/std_luau/mod.rs
+++ b/src/std_luau/mod.rs
@@ -1,0 +1,227 @@
+use mluau::prelude::*;
+use crate::prelude::*;
+
+use mluau::Compiler;
+
+// TODO: lute support
+
+struct EvalError {
+    message: String,
+}
+impl EvalError {
+    fn new(err: LuaError) -> Self {
+        Self {
+            message: err.to_string()
+        }
+    }
+}
+impl LuaUserData for EvalError {
+    fn add_fields<F: LuaUserDataFields<Self>>(fields: &mut F) {
+        fields.add_meta_field("__type", "error"); // allow users to typeof check
+    }
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_meta_method(LuaMetaMethod::ToString, | luau: &Lua, this: &EvalError, _: LuaValue| -> LuaValueResult {
+            this.message.clone().into_lua(luau)
+        });
+    }
+}
+
+enum EvalStdlib {
+    Seal,
+    Safe,
+    None,
+}
+
+struct EvalOptions {
+    name: Option<String>,
+    stdlib: EvalStdlib,
+}
+impl EvalOptions {
+    fn default() -> Self {
+        EvalOptions {
+            name: None,
+            stdlib: EvalStdlib::Safe,
+        }
+    }
+
+    fn from_value(value: LuaValue, function_name: &'static str) -> LuaResult<Self> {
+        let t = match value {
+            LuaValue::Table(t) => Some(t),
+            LuaNil => None,
+            other => {
+                return wrap_err!("{} expected EvalOptions to be a table (with fields stdlib and/or is_bytecode) or nil, got: {:?}", function_name, other);
+            }
+        };
+        if t.is_none() {
+            return Ok(Self::default());
+        }
+
+        // SAFETY: we just checked .is_none()
+        let t = unsafe { t.unwrap_unchecked() };
+
+        let stdlib = match t.raw_get("stdlib")? {
+            LuaValue::String(s) => {
+                let s_bytes = s.as_bytes();
+                if s_bytes == &b"seal"[..] {
+                    EvalStdlib::Seal
+                } else if s_bytes == &b"safe"[..] {
+                    EvalStdlib::Safe
+                } else if s_bytes == &b"none"[..] {
+                    EvalStdlib::None
+                } else {
+                    return wrap_err!("{} expected EvalOptions.stdlib to be \"seal\" or \"safe\" or \"none\" or nil, got an invalid string: {}", function_name, s.display())
+                }
+            },
+            LuaNil => EvalStdlib::Safe,
+            other => {
+                return wrap_err!("{} expected EvalOptions.stdlib to be \"seal\" or \"safe\" or \"none\" or nil, got: {:?}", function_name, other);
+            }
+        };
+
+        let name = match t.raw_get("name")? {
+            Some(LuaValue::String(name)) => {
+                Some(name.to_string_lossy())
+            },
+            Some(LuaNil) | None => {
+                None
+            },
+            Some(other) => {
+                return wrap_err!("{} expected name to be a string or nil, got: {:?}", function_name, other);
+            }
+        };
+
+        Ok(EvalOptions {
+            name,
+            stdlib,
+        })
+    }
+}
+
+fn get_safe_globals(luau: &Lua) -> LuaResult<LuaTable> {
+    let safe_globals = [
+        // luau standard libraries
+        "math", "table", "string", "coroutine", "bit32", "utf8", "os", "debug", "buffer", "vector",
+        // some useful functions
+        "assert", "error", "getmetatable", "setmetatable", "next", "ipairs", "pairs", "rawequal", "rawget", "rawset", "setmetatable", 
+        "tonumber", "tostring", "type", "typeof", "pcall", "xpcall", "unpack", "print"
+        // note that require is purposely not included
+    ];
+    let t = luau.create_table()?;
+    for glob in safe_globals {
+        let value = luau.globals().get::<LuaValue>(glob)?;
+        t.raw_set(glob, value)?;
+    };
+    t.raw_set("_VERSION", "Luau")?;
+    let dummy_require_fn = luau.create_function(|_l: &Lua, _v: LuaValue| -> LuaValueResult {
+        wrap_err!("require is not allowed here!")
+    })?;
+    t.raw_set("require", dummy_require_fn)?;
+    Ok(t)
+}
+
+/// this function is unsafe because invalid bytecode can cause the interpreter to crash and seal to crash
+/// with illegal instruction & core dump. caller is responsible for making sure valid bytecode is passed
+unsafe fn eval(luau: &Lua, src: Vec<u8>, eval_options: EvalOptions) -> LuaValueResult {
+    let name = eval_options.name.unwrap_or("luau.load".to_string());
+    let chunk = match eval_options.stdlib {
+        EvalStdlib::Safe => {
+            luau.load(src).set_name(name).set_environment(get_safe_globals(luau)?)
+        },
+        EvalStdlib::None => {
+            luau.load(src).set_name(name).set_environment(luau.create_table()?)
+        },
+        EvalStdlib::Seal => {
+            luau.load(src).set_name(name)
+        }
+    };
+    let res = match chunk.eval::<LuaValue>() {
+        Ok(value) => value,
+        Err(err) => {
+            LuaValue::UserData(luau.create_userdata(EvalError::new(err))?)
+        }
+    };
+
+    Ok(res)
+}
+
+fn luau_eval(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResult {
+    let function_name = "luau.eval(src: string, options: EvalOptions?)";
+    let src = match multivalue.pop_front() {
+        Some(LuaValue::String(src)) => {
+            if let Ok(src) = src.to_str() {
+                src.as_bytes().to_owned()
+            } else {
+                return wrap_err!(
+                    "{}: Your src appears to be bytecode!\n\nEvaluating bytecode is UNSAFE because it can cause the entire program to crash!! (with an illegal instruction coredump!!!)!\n\nIf you trust your bytecode is valid and safe, use luau.eval_unsafe to evaluate it \n(please don't blame me if seal crashes).",
+                    function_name
+                )
+            }
+        },
+        Some(LuaNil) | None => {
+            return wrap_err!("{} expected src to be a string of Luau source code, but was incorrectly called with zero arguments", function_name);
+        },
+        other => {
+            return wrap_err!("{} expected src to be a string of Luau source code, got: {:?}", function_name, other);
+        }
+    };
+    let eval_options = match multivalue.pop_front() {
+        Some(v) => EvalOptions::from_value(v, function_name)?,
+        None => EvalOptions::default(),
+    };
+
+    // SAFETY: we've verified src is not luau bytecode (which must be invalid utf-8)
+    let res = unsafe { eval(luau, src, eval_options) }?;
+    Ok(res)
+}
+
+// this function is actually unsafe but we can't pass unsafe functions to luau
+fn luau_eval_unsafe(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResult {
+    let function_name = "luau.eval(src: string, options: EvalOptions?)";
+    let src = match multivalue.pop_front() {
+        Some(LuaValue::String(src)) => src.as_bytes().to_owned(),
+        Some(LuaValue::Buffer(buffy))=> buffy.to_vec(),
+        Some(LuaNil) | None => {
+            return wrap_err!("{} expected src to be a string (of either source code or bytecode) or buffer, but was incorrectly called with zero arguments", function_name);
+        },
+        other => {
+            return wrap_err!("{} expected src to be a string (of either source code or bytecode) or buffer, got: {:?}", function_name, other);
+        }
+    };
+    let eval_options = match multivalue.pop_front() {
+        Some(v) => EvalOptions::from_value(v, function_name)?,
+        None => EvalOptions::default(),
+    };
+
+    // SAFETY: caller in Luau is responsible for passing valid bytecode
+    // if/when invalid bytecode is passed to this function, seal will crash with an "illegal instruction" and coredump.
+    let res = unsafe { eval(luau, src, eval_options) }?;
+    Ok(res)
+}
+
+fn luau_bytecode(luau: &Lua, value: LuaValue) -> LuaValueResult {
+    let function_name = "luau.bytecode(src: string)";
+    let src = match value {
+        LuaValue::String(src) => src.to_string_lossy(),
+        other => {
+            return wrap_err!("{} expected src to be a string, got: {:?}", function_name, other);
+        }
+    };
+    let comp = Compiler::new();
+    let res = match comp.compile(src) {
+        Ok(bytecode) => bytecode,
+        Err(err) => {
+            return Ok(LuaValue::UserData(
+                luau.create_userdata(EvalError::new(err))?
+            ))
+        }
+    };
+    ok_buffy(res, luau)
+}
+
+pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
+    TableBuilder::create(luau)?
+        .with_function("eval", luau_eval)?
+        .with_function("eval_unsafe", luau_eval_unsafe)?
+        .with_function("bytecode", luau_bytecode)?
+        .build_readonly()
+}

--- a/tests/luau/std/luau/eval.luau
+++ b/tests/luau/std/luau/eval.luau
@@ -1,0 +1,60 @@
+local luau = require("@std/luau")
+
+local function returnstable()
+    local src = [[
+    return {
+        seal_version = "0.0.6-rc.1"
+    }
+    ]]
+    local content = luau.eval(src)
+    assert(typeof(content) ~= "error", "seal_version table shouldn't be error, should've worked")
+    assert(typeof(content) == "table", "seal_version table should be table")
+    assert((content :: any).seal_version == "0.0.6-rc.1", "should be 0.0.6-rc.1")
+end
+returnstable()
+
+local function errorsshouldntactuallyerror()
+    local bad_code = [[
+    local stringy = "hi"
+    table.insert(stringy, "tfatienftoieifwtf")
+    ]]
+    local res = luau.eval(bad_code)
+    assert(typeof(res) == "error", "bad_code should error")
+    assert(string.match(tostring(res), "invalid argument #1 to 'insert'"), "should invalid arg")
+end
+errorsshouldntactuallyerror()
+
+local function printshouldnotbeavailableinnone()
+    local src = [[print("happiness")]]
+    local res = luau.eval(src, { stdlib = "none" })
+    assert(tostring(res):match("nil"), "print should be attempt to call nil")
+end
+printshouldnotbeavailableinnone()
+
+local function seallibs()
+    local src = [[
+    return function(s: string)
+        local str = require("@std/str")
+        return str.startswith(s, "huh")
+    end
+    ]]
+    local f = luau.eval(src, { stdlib = "seal" }) :: (s: string) -> boolean
+    assert(typeof(f) == "function", "f should be function in seallibs")
+    assert(f("huhmm") == true, "huhmm starts with huh")
+    assert(f("hmm") == false, "hmm does not start with huh")
+end
+seallibs()
+
+local function bytecodes()
+    local src = [[local s = 2; local s = pcall(function() return string.meow() end); return s]]
+    local byc = luau.bytecode(src)
+    assert(typeof(byc) == "buffer", "byc should be buffer")
+    local s, f = pcall(function(): nil
+        luau.eval(buffer.tostring(byc))
+        return nil
+    end)
+    assert(s == false and tostring(f):match("UNSAFE"), "should display big warning")
+    local res = luau.eval_unsafe(byc)
+    assert(res == false, "res should be false because string.meow() will error")
+end
+bytecodes()


### PR DESCRIPTION
Lute support still todo. Separated eval functions into safe and unsafe ones because evaluating bytecode is unsafe and can cause illegal instruction crash. this is documented in the bytecode evaluating function luau.eval_unsafe.