### PR TITLE
Implement fs.watch with notify crate

### DIFF
--- a/.seal/typedefs/std/fs/init.luau
+++ b/.seal/typedefs/std/fs/init.luau
@@ -122,7 +122,9 @@ export type fs = {
 		- You probably want to ignore `"Access"` since it's noisy (unless you need to know which files are currently open)
 		- If you want to listen for files getting added/modified, don't rely on certain kinds/categories.
 			- Check for `WatchEventInfo.is_write` instead of relying on `Modify::Data` or `Create` or `Close::Write`.
-		- If you don't want to loop forever, `break` if when you keep encountering `category == "None"` for a while. 
+		- If you don't want to loop forever, `break` if when you keep encountering `category == "None"` for a while.
+		- To make this function nonblocking (as best as possible), pass 0 milliseconds to `timeout_ms`. 
+			- You'll probably still want to loop it/put it in a function and watch out for `"None"` events.
 
 		## Examples
 

--- a/.seal/typedefs/std/fs/init.luau
+++ b/.seal/typedefs/std/fs/init.luau
@@ -104,6 +104,115 @@ export type fs = {
 	]=]
 	removefile: (path: string) -> (),
 
+	--> fs.watch(paths: string | { string }, options: WatchOptions)
+	--[=[
+		Watch for filesystem changes on one or more `paths`.
+
+		- `WatchOptions.recursive`: defaults `true`; may produce duplicate events if any `paths` overlap,
+		- `WatchOptions.timeout_ms`: in milliseconds, after which the `fs.watch` iterator will return a `"None"` event instead of blocking the VM.
+		Defaults to 10 milliseconds.
+
+		Note that filesystem watching is inherently *messy* and *platform specific*!
+		
+		Don't expect that you'll get the exact same events every time, or that specific `WatchKinds` will be the same
+		for the same operation on different platforms (though they should be similar).
+
+		## Usage
+
+		- You probably want to ignore `"Access"` since it's noisy (unless you need to know which files are currently open)
+		- If you want to listen for files getting added/modified, don't rely on certain kinds/categories.
+			- Check for `WatchEventInfo.is_write` instead of relying on `Modify::Data` or `Create` or `Close::Write`.
+		- If you don't want to loop forever, `break` if when you keep encountering `category == "None"` for a while. 
+
+		## Examples
+
+		Run a Lune script whenever a file in ./src/** changes:
+		```luau
+		local fs = require("@std/fs")
+		local str = require("@std/str")
+		local process = require("@std/process")
+
+		local serializer_script = fs.path.join(".", ".lune", "instance_serializer.luau")
+
+		for category, event in fs.watch("./src") do
+			if category == "Access" or category == "None" then
+				continue -- ignore these, we only need "None" if we want to break loop
+			elseif event.is_write then
+				local modified_path = event.paths[1]
+				local result = process.run {
+					program = "lune",
+					args = {"run", serializer_script, modified_path}
+				}
+			end
+		end
+		```
+
+		Watch only .json config files for changes:
+
+		```luau
+		local options: fs.WatchOptions = {
+			recursive = false,
+			timeout_ms = 2, -- blocks vm for max of 2 milliseconds
+		}
+		
+		local files = fs.listdir(
+			"./src", , event i
+			true, -- recursive
+			function(path: string) -- filter
+				return if string.match(path, "%.json$") or string.match(path, "%.luaurc") 
+					then true 
+					else false
+			end
+		)
+		
+		for _, event in fs.watch(files, options) do
+			if event.is_write then
+				local modified = fs.path.child(event.paths[1])
+				if modified then
+					print(`Config file modified: {modified}!`)
+				end
+			end
+		end
+		```
+		
+		Manually poll a few times:
+
+		```luau
+		local options = {
+			recursive = true,
+			timeout_ms = 2, -- check for 2 seconds
+		}
+		time.wait(1)
+		local poll = fs.watch("./src", options)
+		local cat, event = poll()
+		if cat == "None" then
+			time.wait(1) -- retry
+			cat, event = poll()
+		end
+		if cat == "None" then
+			print("not found")
+		end
+		```
+
+		With a custom timeout:
+
+		```luau
+		local start_time = os.clock()
+		for category, event in fs.watch(script:parent()) do
+			if category == "None" and os.clock() - start_time > 5 then
+				break
+			end
+			if event.is_write then
+				print(event)
+			end
+		end
+		print("hi after 5 seconds")
+		```
+
+		This function uses the Rust `notify` crate as its backend; please refer to its documentation for more specifics.
+	]=]
+	watch: (paths: string | { string }, options: WatchOptions?) -> () -> (WatchEventCategory, WatchEventInfo),
+
 	-- fs.readtree(path: string) -> DirectoryTree
 	--[=[
 		Recursively read contents of directory at `path` into a `fs.DirectoryTree` that can be passed into `fs.writetree` and `DirectoryEntry:add_tree` apis.
@@ -336,6 +445,120 @@ export type FindResult = common_types.FindResult
 export type Entry = common_types.Entry
 export type FileEntry = common_types.FileEntry
 export type DirectoryEntry = common_types.DirectoryEntry
+
+export type WatchOptions = {
+	recursive: boolean?,
+	timeout_ms: number?,
+}
+
+--[=[
+	Top level categories to filter events by.
+
+	Some usage notes:
+	- You should probably ignore `"Access"` unless you need to know which files are currently open.
+	- Don't rely on solely `"Create"` or `"Modify::Data"` to check if a file was created/modified, use `WatchEventInfo.is_write` instead.
+	- `"None"` indicates a timeout was reached; use it to early exit or `break` without blocking the VM.
+]=]
+export type WatchEventCategory = 
+	| "Read" -- note that Read ~= open for reading (which is in Open)
+	| "Execute"
+	| "Open"
+	| "Close"
+	| "Access"
+	| "Create"
+	| "Rename"
+	| "Modify::Data"
+	| "Modify::Metadata"
+	| "Modify::Other"
+	| "Remove"
+	| "Other"
+	| "Unknown"
+	| "None"
+
+export type WatchEventInfo = {
+	paths: { string },
+	kind: WatchKind,
+	--- if the event is *most likely* a write event (`Create::File` or `Modify::Data` or `Close::Write`)
+	is_write: boolean,
+}
+
+--- Represents the specific Event.WatchKind from notify.
+---
+--- Note that relying on these is inherently unreliable as notify tends to combine related events.
+--- Especially if they're received within a short interval of each other.
+--- 
+--- `None::Timeout` is fired if no events have been seen when `WatchOptions.timeout_ms` elapses
+--- for an iteration of `fs.watch`. This allows you to break early without indefinitely blocking the Luau VM.
+export type WatchKind =
+    -- Read -- AccessKind::Read
+    | "Read"
+
+    -- Execute -- AccessKind::Open(Execute)
+    | "Open::Execute"
+
+    -- Open -- AccessKind::Open(_)
+    | "Open::Read"
+    | "Open::Write"
+    | "Open::Other"
+
+    -- Close -- AccessKind::Close(_)
+    | "Close::Execute"
+    | "Close::Read"
+    | "Close::Write"
+    | "Close::Other"
+    | "Close::Any"
+
+    -- Access -- AccessKind::Any, AccessKind::Open(Any), AccessKind::Other
+    | "Open::Any"
+    | "Access::Any"
+    | "Access::Other"
+
+    -- Create -- CreateKind
+    | "Create::File"
+    | "Create::Directory"
+    | "Create::Other"
+    | "Create::Any"
+
+    -- Rename -- ModifyKind::Name
+    | "Rename::Any"
+    | "Rename::From"
+    | "Rename::To"
+    | "Rename::Both"
+    | "Rename::Other"
+
+    -- Modify::Data -- ModifyKind::Data
+    | "Modify::Data"
+    | "Modify::Data::Content"
+    | "Modify::Data::Size"
+    | "Modify::Data::Other"
+
+    -- Modify::Metadata -- ModifyKind::Metadata
+    | "Modify::Metadata::AccessTime"
+    | "Modify::Metadata::WriteTime"
+    | "Modify::Metadata::Ownership"
+    | "Modify::Metadata::Permissions"
+    | "Modify::Metadata::Extended"
+    | "Modify::Metadata::Other"
+    | "Modify::Metadata::Any"
+
+    -- Modify::Other -- ModifyKind::Any, ModifyKind::Other
+    | "Modify::Any"
+    | "Modify::Other"
+
+    -- Remove -- RemoveKind
+    | "Remove::File"
+    | "Remove::Directory"
+    | "Remove::Other"
+    | "Remove::Any"
+
+    -- Other -- EventKind::Other
+    | "Other"
+
+    -- Unknown -- EventKind::Any
+    | "Unknown"
+
+	-- No event received after `timeout_ms` ms elapsed
+	| "None::Timeout"
 
 
 return {} :: fs

--- a/.seal/typedefs/std/fs/path.luau
+++ b/.seal/typedefs/std/fs/path.luau
@@ -38,12 +38,12 @@ export type PathLib = {
 	]=]
 	absolutize: (path: string) -> string,
 	--[=[
-		Returns a normalized (cleaned) version of `path` with a consistent path separator and with duplicate separators removed.
+		Returns a normalized (cleaned) version of `path` with a consistent path separator and with duplicate separators and unneeded relative path symbol removed.
 
-		Uses '/' as the path separator unless `path` is a Windows-style absolute path, in which case it'll use a backslash instead.
+		By default, uses '/' as the path separator unless `path` is a Windows-style absolute path, in which case it'll use a backslash instead.
 
 		```luau
-		local mixed_path = [[./hi/im/a\file.txt]]
+		local mixed_path = [[./hi/im/a\./file.txt]]
 		print(path.normalize(mixed_path)) --> "./hi/im/a/file.txt"
 
 		-- absolute paths on windows use \
@@ -54,6 +54,9 @@ export type PathLib = {
 		local redundant_separators = [[C:\\Users\\Example//Documents////project\main.luau]]
 		print(path.normalize(redundant_separators)) --> "C:\Users\Example\Documents\project\main.luau"
 		```
+
+		For Windows-style absolute paths, `path.normalize` handles both drive letter paths like `"C:\Users\Username\Documents\..."`
+		as well as UNC paths like `"\\network\share\text.txt"` or `"\\?\wsl\mnt\..."`.
 	]=]
 	normalize: (path: string) -> string,
 	--[=[

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -530,6 +536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +773,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +843,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +889,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -908,6 +963,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "mlua-sys"
 version = "0.8.2"
 source = "git+https://github.com/mluau/mluau.git#2518f393f9485dc12e61a31051444318df8bc69d"
@@ -934,6 +1001,31 @@ dependencies = [
  "serde",
  "serde-value",
 ]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossbeam-channel",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num-bigint-dig"
@@ -1190,7 +1282,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1280,7 +1372,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1371,6 +1463,7 @@ dependencies = [
  "include_dir",
  "libc",
  "mluau",
+ "notify",
  "petname",
  "rand",
  "regex",
@@ -2092,7 +2185,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ aho-corasick = "1.1.3"
 unicode_reader = "1.0.2"
 petname = { version = "2.0.2", features = ["default-rng", "default-words"] }
 libc = "0.2.174"
+notify = { version = "8.2.0", features = ["crossbeam-channel"] }
 
 [profile.dev.package.num-bigint-dig]
 opt-level = 3 # otherwise rsa keygen takes forever

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -8,7 +8,7 @@ pub fn error(_luau: &Lua, error_value: LuaValue) -> LuaValueResult {
 
 pub fn warn(luau: &Lua, warn_value: LuaValue) -> LuaValueResult {
     let formatted_text = std_io::output::format_output(luau, warn_value)?;
-    println!("{}{}{}", colors::BOLD_YELLOW, formatted_text, colors::RESET);
+    eprintln!("{}{}{}", colors::BOLD_YELLOW, formatted_text, colors::RESET);
     Ok(LuaNil)
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,6 +16,15 @@ pub fn ok_function(f: fn(&Lua, LuaValue) -> LuaValueResult, luau: &Lua) -> LuaVa
     Ok(LuaValue::Function(luau.create_function(f)?))
 }
 
+pub fn ok_function_mut<F, I, Fn>(f: Fn, luau: &Lua) -> LuaValueResult
+where
+    F: FromLuaMulti + 'static,
+    I: IntoLuaMulti + 'static,
+    Fn: FnMut(&Lua, F) -> LuaResult<I> + 'static,
+{
+    Ok(LuaValue::Function(luau.create_function_mut(f)?))
+}
+
 pub fn ok_string<S: AsRef<[u8]>>(s: S, luau: &Lua) -> LuaValueResult {
     Ok(LuaValue::String(luau.create_string(s)?))
 }

--- a/src/setup/setup.luau
+++ b/src/setup/setup.luau
@@ -116,7 +116,7 @@ local function setup(config: SetupConfig?)
             json.writefile(settings_path, updated)
             print(`Updated .vscode/settings.json at '{settings_path}'`)
         else
-            fs.dir.ensure(".vscode")
+            fs.dir.ensure(cwd:join(".vscode"))
                 :add_file("settings.json", json.encode(vscode_defaults))
         end
     elseif config.editor == "zed" then

--- a/src/std_fs/entry.rs
+++ b/src/std_fs/entry.rs
@@ -299,7 +299,7 @@ pub fn create(luau: &Lua, path: &str, function_name: &str) -> LuaValueResult {
         }
     };
     if metadata.is_dir() {
-       ok_table(directory_entry::create(luau, path))
+        ok_table(directory_entry::create(luau, path))
     } else if metadata.is_file() {
         ok_table(file_entry::create(luau, path))
     } else {

--- a/src/std_fs/watch.rs
+++ b/src/std_fs/watch.rs
@@ -1,0 +1,255 @@
+use mluau::prelude::*;
+use crate::prelude::*;
+use crate::std_fs::pathlib::normalize_path;
+use std::{path::Path, time::Duration};
+use std::sync::{Arc, Mutex};
+
+use notify::{event::{
+    AccessKind, AccessMode, 
+    CreateKind, DataChange, 
+    MetadataKind, ModifyKind, 
+    RemoveKind, RenameMode}, 
+    Event, EventKind, 
+    RecursiveMode, Watcher
+};
+use crossbeam_channel::RecvTimeoutError;
+
+#[derive(Clone, Copy)]
+pub struct WatchOptions {
+    recursive: bool,
+    timeout: Duration,
+}
+impl WatchOptions {
+    pub fn default() -> Self {
+        Self {
+            recursive: true,
+            timeout: Duration::from_millis(10),
+        }
+    }
+    pub fn from_table(t: LuaTable, function_name: &'static str) -> LuaResult<Self> {
+        let recursive = match t.raw_get("recursive")? {
+            LuaValue::Boolean(b) => b,
+            LuaNil => true,
+            other => {
+                return wrap_err!("{} expected WatchOptions.recursive to be a boolean (default true), got: {:?}", function_name, other);
+            }
+        };
+        let timeout = match t.raw_get("timeout_ms")? {
+            LuaValue::Integer(i) => {
+                Duration::from_millis(int_to_u64(i, function_name, "timeout_ms")?)
+            },
+            LuaValue::Number(f) => {
+                Duration::from_millis(float_to_u64(f, function_name, "timeout_ms")?)
+            },
+            LuaNil => Duration::from_millis(10),
+            other => {
+                return wrap_err!("{} expected WatchOptions.timeout_ms to be a number (in milliseconds) or nil, got: {:?}", function_name, other);
+            }
+        };
+        
+        Ok(Self { 
+            recursive,
+            timeout,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct EventCategory {
+    kind: EventKind,
+}
+impl EventCategory {
+    fn new(kind: EventKind) -> Self {
+        Self {
+            kind,
+        }
+    }
+    fn category(self) -> &'static str {
+        match self.kind {
+            EventKind::Access(access) => match access {
+                AccessKind::Read => "Read",
+                AccessKind::Open(AccessMode::Execute) => "Execute",
+                // these are noisy so just put them under access
+                AccessKind::Open(AccessMode::Any) => "Access",
+                AccessKind::Open(_) => "Open",
+                AccessKind::Close(_) => "Close",
+                _ => "Access",
+            },
+            EventKind::Create(_) => "Create",
+            EventKind::Modify(modify) => match modify {
+                ModifyKind::Data(_) => "Modify::Data",
+                ModifyKind::Metadata(_) => "Modify::Metadata",
+                ModifyKind::Name(_) => "Rename",
+                _ => "Modify::Other",
+            },
+            EventKind::Remove(_) => "Remove",
+            EventKind::Other => "Other",
+            EventKind::Any => "Unknown",
+        }
+    }
+    fn stringify_kind(self) -> &'static str {
+        match self.kind {
+            EventKind::Access(access) => match access {
+                AccessKind::Read => "Read",
+                AccessKind::Open(mode) => match mode {
+                    AccessMode::Execute => "Open::Execute",
+                    AccessMode::Read => "Open::Read",
+                    AccessMode::Write => "Open::Write",
+                    AccessMode::Other => "Open::Other",
+                    AccessMode::Any => "Open::Any",
+                },
+                AccessKind::Close(mode) => match mode {
+                    AccessMode::Execute => "Close::Execute",
+                    AccessMode::Read => "Close::Read",
+                    AccessMode::Write => "Close::Write",
+                    AccessMode::Other => "Close::Other",
+                    AccessMode::Any => "Close::Any",
+                },
+                AccessKind::Any => "Access::Any",
+                AccessKind::Other => "Access::Other",
+            },
+            EventKind::Create(create) => match create {
+                CreateKind::File => "Create::File",
+                CreateKind::Folder => "Create::Directory",
+                CreateKind::Other => "Create::Other",
+                CreateKind::Any => "Create::Any",
+            },
+            EventKind::Modify(modify) => match modify {
+                ModifyKind::Name(rename) => match rename {
+                    RenameMode::Any => "Rename::Any",
+                    RenameMode::From => "Rename::From",
+                    RenameMode::To => "Rename::To",
+                    RenameMode::Both => "Rename::Both",
+                    RenameMode::Other => "Rename::Other",
+                },
+                ModifyKind::Data(data) => match data {
+                    DataChange::Any => "Modify::Data",
+                    DataChange::Content => "Modify::Data::Content",
+                    DataChange::Size => "Modify::Data::Size",
+                    DataChange::Other => "Modify::Data::Other",
+                },
+                ModifyKind::Metadata(meta) => match meta {
+                    MetadataKind::AccessTime => "Modify::Metadata::AccessTime",
+                    MetadataKind::WriteTime => "Modify::Metadata::WriteTime",
+                    MetadataKind::Ownership => "Modify::Metadata::Ownership",
+                    MetadataKind::Permissions => "Modify::Metadata::Permissions",
+                    MetadataKind::Extended => "Modify::Metadata::Extended",
+                    MetadataKind::Other => "Modify::Metadata::Other",
+                    MetadataKind::Any => "Modify::Metadata::Any",
+                },
+                ModifyKind::Any => "Modify::Any",
+                ModifyKind::Other => "Modify::Other",
+            },
+            EventKind::Remove(remove) => match remove {
+                RemoveKind::File => "Remove::File",
+                RemoveKind::Folder => "Remove::Directory",
+                RemoveKind::Other => "Remove::Other",
+                RemoveKind::Any => "Remove::Any",
+            },
+            EventKind::Other => "Other",
+            EventKind::Any => "Unknown",
+        }
+    }
+}
+
+fn create_event_table(event: Event, event_category: EventCategory, luau: &Lua) -> LuaResult<LuaTable> {
+    let paths_table = luau.create_table_with_capacity(event.paths.len(), 0)?;
+    for path in event.paths.iter() {
+        let s = normalize_path(path.to_string_lossy().as_ref());
+        paths_table.raw_push(luau.create_string(s)?)?;
+    }  
+    TableBuilder::create(luau)?
+        .with_value("paths", paths_table)?
+        .with_value("kind", ok_string(event_category.stringify_kind(), luau)?)?
+        .with_value("is_write", {
+            matches!(event_category.stringify_kind(), "Create::File" | "Close::Write" | "Modify::Data")
+        })?
+        .build_readonly()
+}
+
+pub fn watch<P: AsRef<Path>>(luau: &Lua, paths: Vec<P>, options: WatchOptions, function_name: &'static str) -> LuaValueResult {
+    let (tx, rx) = crossbeam_channel::unbounded::<Event>();
+    
+    let mut watcher = match notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
+        match res {
+            Ok(event) =>  {
+                tx.send(event).unwrap_or_else(|err| {
+                    eprintln!("Unable to send event due to {}", err);
+                });
+            },
+            Err(err) => {
+                eprintln!("Unable to send message due to {}", err);
+            }
+        };
+    }) {
+        Ok(watcher) => watcher,
+        Err(err) => {
+            return wrap_err!("{} unable to create 'notify' filesystem watcher due to err: {}", function_name, err);
+        }
+    };
+    let recursive = if options.recursive { RecursiveMode::Recursive } else { RecursiveMode::NonRecursive };
+    for path in paths {
+        if let Err(err) = watcher.watch(path.as_ref(), recursive) {
+            return wrap_err!("{} unable to watch path '{}' due to err: {}", function_name, path.as_ref().display(), err);
+        }
+    }
+
+    let arc_rx = Arc::new(Mutex::new(rx));
+    let watcher = Arc::new(watcher);
+
+    ok_function_mut({
+        let arc_rx = Arc::clone(&arc_rx);
+        move | luau: &Lua, _value: LuaValue | -> LuaMultiResult {
+            // need to clone watcher here just to keep it alive (so it doesn't disconnect while we're iterating)
+            let _watcher = Arc::clone(&watcher);
+            let rx = match arc_rx.try_lock() {
+                Ok(rx) => rx,
+                Err(err) => {
+                    panic!("{} unexpectedly cannot lock the crossbeam event receiver due to err: {}", function_name, err);
+                }
+            };
+            match rx.recv_timeout(options.timeout) {
+                // if an event is received we return its category and an event info table describing
+                // what specific kind of event was received and what paths were accessed/modified/written to/etc.
+                Ok(event) => {
+                    let event_category = EventCategory::new(event.kind);
+                    let event_table = ok_table(create_event_table(event, event_category, luau))?;
+                    let category_str = ok_string(event_category.category(), luau)?;
+                    Ok(LuaMultiValue::from_vec(vec![category_str, event_table]))
+                },
+                // if no event recv by timeout we return "Timeout", { kind = "None", paths = {} }
+                // so we don't indefinitely block the luau vm until the next event recv
+                Err(RecvTimeoutError::Timeout) => {
+                    Ok(LuaMultiValue::from_vec(vec![
+                        ok_string("None", luau)?,
+                        ok_table(
+                            TableBuilder::create(luau)?
+                                .with_value("paths", luau.create_table()?)?
+                                .with_value("kind", "None::Timeout")?
+                                .with_value("is_write", false)?
+                                .build()
+                        )?
+                    ]))
+                },
+                // the channel has somehow gotten disconnected, this means either the sender panicked or smth
+                // or we somehow dropped the watcher
+                // - either case probably means there's a bug in seal or notify or crossbeam
+                // - if we just returned nil here to stop iteration, users would wonder why their for loop stopped iterating
+                // - if we wrap_err! here, users would pcall this and we wouldn't know that users are actually getting this
+                // - so we panic so users may report this and we can investigate
+                Err(RecvTimeoutError::Disconnected) => {
+                    // Ok(LuaMultiValue::from_vec(vec![LuaNil]))
+                    panic!(
+                        "{}: {}\n{}\n{}\n{}\n{}",
+                        "filesystem watcher channel disconnected unexpectedly",
+                        "This closure owns arc_rx and should not lose its sender unless:",
+                        "  - the watcher was dropped prematurely,",
+                        "  - the notify callback panicked",
+                        "  - there's a bug in seal, crossbeam, or notify itself.",
+                        "Please report this with reproduction steps if possible.",
+                    );
+                }
+            }
+        }
+    }, luau)
+}

--- a/tests/luau/std/fs/pathlib.luau
+++ b/tests/luau/std/fs/pathlib.luau
@@ -93,7 +93,7 @@ local function normalize()
 	local windows_absolute = [[C:\Users\sealey\Desktop\Repositories\seal]]
 	assert(path.normalize(windows_absolute) == windows_absolute, "windows absolute paths shouldn't be forward slashed")
 
-	local mixed_windows_absolute = [[C:\Users\sealey\Desktop\Repositories\seal/main.luau]]
+	local mixed_windows_absolute = [[C:\Users\sealey\Desktop\Repositories\seal\./main.luau]]
 	assert(
 		path.normalize(mixed_windows_absolute) == [[C:\Users\sealey\Desktop\Repositories\seal\main.luau]],
 		"mixed windows absolute paths should be normalized to backslash"
@@ -104,6 +104,45 @@ local function normalize()
 		path.normalize(with_repeated_slashes) == [[C:\Users\sealey\hehe\weird\slashes.hmm]],
 		"repeated slashes not normalized?"
 	)
+
+	local relative_parent = [[..\.././meow.txt]]
+	-- print(path.normalize(relative_parent))
+	assert(
+		path.normalize(relative_parent) == [[../../meow.txt]],
+		"relative parent prefix shouldn't be stripped when we don't know what's in front"
+	)
+
+	local unc_paths = {
+		[[\\server01\.//public]],
+		[[\\fileserver\docs\reports\2025\summary.pdf]],
+		[[\\datahub\shared folders\team alpha\plan.docx\.]],
+		[[\\server02\admin$\config.ini]],
+		[[\\192.168.1.100\media\video.mp4]],
+		[[\\Server03\Finance\Q4\Budget.xlsx]],
+		[[\\backup\archives\..\2025\August\week3\logs\system.log]],
+		[[\\server04\共享\项目\计划.docx]],
+		[[\\server05\downloads\]],
+		[[\\?\UNC\server06\weird|path\file.txt]],
+	}
+	local expected_unc_paths = {
+		[[\\server01\public]],
+		[[\\fileserver\docs\reports\2025\summary.pdf]],
+		[[\\datahub\shared folders\team alpha\plan.docx]],
+		[[\\server02\admin$\config.ini]],
+		[[\\192.168.1.100\media\video.mp4]],
+		[[\\Server03\Finance\Q4\Budget.xlsx]],
+		[[\\backup\2025\August\week3\logs\system.log]],
+		[[\\server04\共享\项目\计划.docx]],
+		[[\\server05\downloads]],
+		[[\\?\UNC\server06\weird|path\file.txt]],
+	}
+	for index, p in unc_paths do
+		local res = path.normalize(p)
+		assert(
+			res == expected_unc_paths[index], 
+			`path.normalize {index}; {res} not matched {expected_unc_paths[index]}`
+		)
+	end
 end
 
 normalize()

--- a/tests/luau/std/fs/watch/child.luau
+++ b/tests/luau/std/fs/watch/child.luau
@@ -1,0 +1,22 @@
+local fs = require("@std/fs")
+local time = require("@std/time")
+local tp = fs.path.join(script:parent(), "testfile.txt")
+if channel then
+    fs.file.try_remove(tp) -- Remove::File
+    time.wait(1)
+    fs.writefile(tp, "content") -- Modify::Data & Close
+    time.wait(1)
+    local c = fs.readfile(tp) -- apparently nothing on linux?
+    time.wait(0.125)
+    fs.writefile(tp, "cats") -- Modify::Data & Close
+    time.wait(1)
+    fs.file.try_remove(tp) -- Remove::File
+    time.wait(0.25)
+    local cats_dir = fs.dir.ensure( -- Create::Directory
+        fs.path.join(fs.path.parent(tp) :: string, "cats")
+    )
+    -- is this somehow a Modify::Data?? instead of a Create::File and then Modify::Data?
+    cats_dir:add_file("taz.json", [[{"name":"Taz"}]]) -- & Close
+    time.wait(0.16)
+    cats_dir:remove() -- 1 or 2 Removes
+end

--- a/tests/luau/std/fs/watch/watch.luau
+++ b/tests/luau/std/fs/watch/watch.luau
@@ -1,0 +1,95 @@
+local fs = require("@std/fs")
+local env = require("@std/env")
+local thread = require("@std/thread")
+local format = require("@std/io/format")
+local unformat = require("@std/io/output").unformat
+
+local function watchiter()
+    -- child thread calls fs lib fns to simulate 'reproducible' fs events
+    local handle = thread.spawn {
+        path = "./child.luau"
+    }
+
+    local start_time = os.clock()
+
+    local event_categories: { fs.WatchEventCategory } = {}
+
+    local files_created: { string } = {}
+    local creates_found = {
+        files = 0,
+        dirs = 0,
+    }
+    local removes_found = {
+        files = 0,
+        dirs = 0,
+    }
+    local writes_found = 0
+
+    for cat, event in fs.watch(script:parent()) do -- watch only this ./tests/luau/std/fs/watch dir
+        if cat == "Access" then
+            continue -- these r just noise
+        elseif cat == "None" then
+            if os.clock() - start_time > 8 then
+                break
+            else
+                continue
+            end
+        end
+
+        print({
+            event = cat,
+            path = event.paths[1],
+            kind = event.kind,
+        })
+
+        if cat == "Create" then
+            if event.kind == "Create::Directory" then
+                creates_found.dirs += 1
+            else
+                -- creates are unreliable!
+                creates_found.files += 1
+                for _, f in event.paths do
+                    table.insert(files_created, f)
+                end
+            end
+        elseif event.is_write then
+            writes_found += 1
+            if not table.find(files_created, event.paths[1]) then
+                creates_found.files += 1
+            end
+        elseif cat == "Modify::Other" then
+            -- note warn prints to stderr and therefore should fail ci
+            warn(`why Modify::Other on {env.os} got: {format(event)}`)
+            writes_found += 1
+        elseif cat == "Remove" then
+            if event.kind == "Remove::File" then
+                removes_found.files += 1
+            elseif event.kind == "Remove::Directory" then
+                removes_found.dirs += 1
+            else
+                warn(
+                    `got remove that wasn't file or dir on platform {env.os}; got: {format(event)}`
+                )
+            end
+        end
+
+        table.insert(event_categories, cat)
+    end
+
+    -- make sure we didn't wait too long or block longer than expected
+    -- we want to make sure if the loop actually should break after 8 seconds nothing blocks it
+    -- from exiting around 8.0 -> 8.5ish seconds in
+    local now = os.clock() - start_time
+    assert(now > 8 and now < 9, `expected loop to exit during its 8-9th second, got: {now}`)
+
+    handle:join()
+
+    local formatted_events = unformat(format(event_categories))
+
+    assert(creates_found.files >= 2, `at least 2 files should be created (testfile.txt and taz.json), got: {format(creates_found)} | events {formatted_events}`)
+    assert(creates_found.dirs == 1, `only one directory (cats) should've been created, got: {format(creates_found)} | events {formatted_events}`)
+    assert(removes_found.dirs == 1, "1 directory should've been removed: cats")
+    assert(removes_found.files >= 1, "at least 1 file should've been removed (content.txt; taz.json might be removed w/ parent dir)")
+    assert(writes_found >= 3, "at least 3 files should've been modified (testfile.txt twice, taz.json once)")
+end
+watchiter()

--- a/tests/scripts/seal_setup_test.luau
+++ b/tests/scripts/seal_setup_test.luau
@@ -26,7 +26,7 @@ local function sealsetup()
 		cwd = project_path,
 	}
 	if not seal_setup_result.ok then
-		print(seal_setup_result)
+		print(seal_setup_result.stderr)
 	end
 	assert(seal_setup_result.ok == true, "seal setup not ok?")
 


### PR DESCRIPTION
Implements a simple iterator API to loop through filesystem events as they come in. Supports blocking and custom nonblocking ways to use the API, alongside 3 example usecases. I have simplified categories so users dont have a billion kinds in autocomplete (all kinds still accessible via indexing on event.kind). To check for writes/file updates, use event.is_write. Since we expect users will only call fs.watch a few times maximum (most likely only one) per seal script, each watcher has a static lifetime and will be cleaned up when seal exits.