### PR TITLE
Fix fs.path.join with absolute paths, add ability to get project paths easily, fs.path/dir convenience functions

### DIFF
--- a/.seal/typedefs/globals.d.luau
+++ b/.seal/typedefs/globals.d.luau
@@ -15,6 +15,7 @@ declare script: {
 	context: string?,
 	path: (self: any) -> string,
 	parent: (self: any) -> string,
+    project: (self: any) -> string,
 }
 
 declare channel: {

--- a/.seal/typedefs/std/fs/dir.luau
+++ b/.seal/typedefs/std/fs/dir.luau
@@ -36,7 +36,51 @@ export type DirLib = setmetatable<{
 		## Errors
 		- if provided invalid arguments (`path` is not a valid utf-8 encoded string that could exist on the filesystem)
 	]=]
-	try_remove: (path: string) -> (boolean, "Ok" | "PermissionDenied" | "NotFound" | "NotADirectory" | "Other", string?)
+	try_remove: (path: string) -> (boolean, "Ok" | "PermissionDenied" | "NotFound" | "NotADirectory" | "Other", string?),
+	--[=[
+		Returns a `DirectoryEntry` corresponding to the user's home directory, erroring if not found.
+
+		## Usage
+
+		```luau
+		local zip_downloads = fs.dir.home()
+			:expect_dir("Downloads")
+			:list(false, function(path: string)
+				return str.endswith(path, ".zip")
+			end)
+		```
+	]=] 
+	home: () -> DirectoryEntry,
+	--[=[
+		Constructs a `DirectoryEntry` from the user's current working directory (cwd)
+	
+		If you're looking for project-relative pathing, I recommend using `fs.dir.project()` instead, as those will work no matter
+		where the user is when they execute your code.
+	]=]
+	cwd: () -> DirectoryEntry,
+	--[=[
+		Constructs a `DirectoryEntry` from the script's current *seal* project.
+
+		Use this for most project-relative paths instead of `fs.path.cwd` or `fs.dir.cwd` usages.
+
+		## Errors
+
+		- if a *seal* project couldn't be found exactly `n` project parents relative to `script:path()`.
+		- use `fs.path.project` instead if you want to get the *seal* project without erroring.
+
+		## Usage
+
+		```luau
+		local fs = require("@std/fs")
+		local str = require("@std/str")
+		
+		local input_files = fs.dir.project()
+			:expect_dir("input")
+			:list(false, function(path: string) 
+				return str.endswith(path, ".csv")
+			end)
+	]=]
+	project: (n: number?) -> DirectoryEntry,
 }, {
 	--[=[
 	Convenient and slightly more efficient alternative to `fs.find(path):try_dir()`

--- a/.seal/typedefs/std/fs/path.luau
+++ b/.seal/typedefs/std/fs/path.luau
@@ -77,8 +77,19 @@ export type PathLib = {
 	child: (path: string) -> string?,
 	--- returns the user's home directory, also known as `~`
 	home: () -> string,
-	--- returns the current working directory, errors if not found or is invalid utf-8
+	--- returns the current working directory, errors if not found or invalid utf-8.
+	---
+	--- Consider using `fs.path.project()` or `fs.dir.project()` instead if you want paths to be relative
+	--- to the current project instead of relying on the user's cwd.
 	cwd: () -> string,
+	--[=[
+		Returns the *seal* project directory `n` projects up, relative to the current `script:path()`.
+
+		To get the closest project directory to the current file, use `fs.path.project()`.
+
+		Returns the project directory if found, or `nil` if no project directory was found exactly `n` projects up.
+	]=]
+	project: (n: number?) -> string?
 }
 
 return {} :: PathLib

--- a/src/setup/setup.luau
+++ b/src/setup/setup.luau
@@ -190,6 +190,17 @@ local function setup(config: SetupConfig?)
             :add_file("guided_tour.luau", seal_setup.GUIDED_TOUR_SRC)
     end
 
+    print(`Created new {
+        if config.codebase == "project" then 
+            colors.bold.blue("project") 
+        else
+            colors.bold.red("script")
+    } codebase in your cwd for {colors.green(config.editor)}! Typedefs {
+        if config.typedefs == "gen" then
+            "were generated here in ./.seal/typedefs"
+        else 
+            "are linked to your existing seal directory"
+    }.\nhappy coding (•ᴥ•)!`)
 end
 
 function get_updated_luaurc(existing: json.JsonData, default: json.JsonData): json.JsonData

--- a/tests/luau/globals/script.luau
+++ b/tests/luau/globals/script.luau
@@ -1,0 +1,18 @@
+local fs = require("@std/fs")
+
+local function parent()
+    assert(
+        fs.path.child(script:parent()) == "globals",
+        "parent of this script should be globals"
+    )
+end
+parent()
+
+local function projectdir()
+    local pr = script:project()
+    assert(
+        fs.path.child(pr) == "seal",
+        "lol did you rename the repository (project dir expected to be seal)"
+    )
+end
+projectdir()

--- a/tests/luau/std/fs/dirlib.luau
+++ b/tests/luau/std/fs/dirlib.luau
@@ -46,7 +46,6 @@ if env.os ~= "Windows" and env.os ~= "Android" then -- returns NotFound on Windo
 	tryremovepermissiondenied()
 end
 
-
 local function tryremovenotfound()
 	local not_found_path = fs.path.join(data_dir.path, "notfounddir")
 	local success, result = fs.dir.try_remove(not_found_path)
@@ -54,3 +53,31 @@ local function tryremovenotfound()
 end
 
 tryremovenotfound()
+
+local function thisproject()
+	local src_files = fs.dir.project():expect_dir("src"):list(true, function(path: string)
+		return if string.match(path, "%.rs$") then true else false
+	end)
+	local tt = require("@extra/tt")
+	src_files = tt.arraymap(src_files, function(_, v)
+		return fs.path.child(v :: string)
+	end)
+	assert(
+		table.find(src_files, "main.rs") ~= nil,
+		"shoouild be able to find main.rs in the project src"
+	)
+end
+
+thisproject()
+
+local function dirhome()
+	fs.dir.home():list(false)
+end
+
+dirhome()
+
+local function cwd()
+	fs.dir.cwd():expect_dir("src")
+end
+
+cwd()

--- a/tests/luau/std/fs/pathlib.luau
+++ b/tests/luau/std/fs/pathlib.luau
@@ -157,3 +157,10 @@ local function normalize()
 end
 
 normalize()
+
+local function project()
+	local proj = path.project()
+	assert(fs.path.child(proj :: any) ~= nil, "why is project dir nil hmm")
+end
+
+project()

--- a/tests/luau/std/fs/pathlib_join.luau
+++ b/tests/luau/std/fs/pathlib_join.luau
@@ -1,17 +1,15 @@
 local fs = require("@std/fs")
 local env = require("@std/env")
 
-local path = fs.path
-
 local function simplepaths()
-	assert(path.join(".", "src", "main.rs") == "./src/main.rs", "simple paths broke?")
+	assert(fs.path.join(".", "src", "main.rs") == "./src/main.rs", "simple paths broke?")
 end
 
 simplepaths()
 
 local function slashesgetstripped()
-	local p = `/{path.join("cats", "/dogs")}/`
-	local slashed = path.join("./", p)
+	local p = `/{fs.path.join("cats", "/dogs")}/`
+	local slashed = fs.path.join("./", p)
 	assert(slashed == "./cats/dogs", "slashes didnt get stripped?")
 end
 
@@ -19,15 +17,82 @@ slashesgetstripped()
 
 if env.os == "Windows" then
 	local function relativebackslashpaths()
-		local p = path.join(".\\", "src", "main.rs")
+		local p = fs.path.join(".\\", "src", "main.rs")
 		assert(p == ".\\src\\main.rs", "windows backslash relative paths not work?")
 	end
 	relativebackslashpaths()
 end
 
 local function appendcwd()
-	local testpath = path.join(path.cwd(), "tests")
-	assert(path.exists(testpath), `where the ./tests at? (path: {testpath})`)
+	local testpath = fs.path.join(fs.path.cwd(), "tests")
+	assert(fs.path.exists(testpath), `where the ./tests at? (path: {testpath})`)
 end
 
 appendcwd()
+
+local function winabsolutes()
+	local winpath = fs.path.join("C:", "Users", "Me", "Downloads", "meow.jpeg")
+	assert(winpath == [[C:\Users\Me\Downloads\meow.jpeg]], "winpath not match")
+end
+
+winabsolutes()
+
+local function absolutes()
+	local firstcomproot = fs.path.join("/usr", "home")
+	assert(
+		firstcomproot == "/usr/home",
+		"weird first component /usr got stripped?"
+	)
+	local usr_path = fs.path.join("/", "usr", "home")
+	assert(
+		usr_path == "/usr/home",
+		`should be /usr/home, got: {usr_path}`
+	)
+end
+
+absolutes()
+
+local function uncsplease()
+	local server_01 = fs.path.join([[\\]], "server01", "public")
+	assert(
+		server_01 == [[\\server01\public]],
+		"server01 unc broke?"
+	)
+	local server_utf8 = fs.path.join([[\\server04]], "共享", "项目\\计划.docx")
+	assert(
+		server_utf8 == [[\\server04\共享\项目\计划.docx]],
+		"server_utf8 broke?"
+	)
+	local questionmarkunc = fs.path.join([[\\]], "?", [[\UNC]], "server06", [[\downloads]], "file.txt")
+	assert(
+		questionmarkunc == [[\\?\UNC\server06\downloads\file.txt]],
+		"questionmarkunc not match?"
+	)
+end
+
+uncsplease()
+
+local function unrelatives()
+	local unrel = fs.path.join("cats", "dogs", "animal.txt")
+	assert(
+		unrel == "cats/dogs/animal.txt",
+		"simple unrelative path component should work without prepending any relative"
+	)
+end
+
+unrelatives()
+
+local function tildeing()
+	local localdotbin = fs.path.join("~", ".local", "bin")
+	assert(
+		localdotbin == "~/.local/bin",
+		"localdotbin not binning"
+	)
+	local windowslocaldotbin = fs.path.join("~\\", ".local", "bin")
+	assert(
+		windowslocaldotbin == [[~\.local\bin]],
+		"windows local bin not binning (not \\ separator?)"
+	)
+end
+
+tildeing()

--- a/tests/run.luau
+++ b/tests/run.luau
@@ -12,7 +12,7 @@ type FailedTest = {
     err: string,
 }
 
-type IgnoredFunctionbyName = {
+type IgnoredFunctionByName = {
     path: string,
     reason: string,
 }
@@ -23,7 +23,7 @@ type IgnoredFunctionByPath = {
 }
 
 type IgnoredFunctionsByName = {
-    [string]: IgnoredFunctionbyName
+    [string]: IgnoredFunctionByName
 }
 
 type IgnoredFunctionsByPath = {
@@ -68,7 +68,7 @@ local function get_ignored_functions(test_files: { string }): (IgnoredFunctionsB
         local last_reason: string = ""
         local grab_next_line = false
         local looking_for_asserts_in_function: string? = nil
-        
+
         for n, line in fs.readlines(test_path) do
             if grab_next_line then
                 local function_name = string.match(line, "%s*local function ([%w_]+)%(")


### PR DESCRIPTION
Adds easy way to get the current script's project (fs.path.project, script:project), adds DirectoryEntry convenience functions for most common usecases. Fixes path.join issue with fs.path.join("/", "someplace")