### PR TITLE
Fix: p, pp, and dp should return their input values

### DIFF
--- a/src/std_io/format.rs
+++ b/src/std_io/format.rs
@@ -3,7 +3,7 @@ use mluau::prelude::*;
 
 use regex::Regex;
 
-pub fn process_debug_values(value: LuaValue, result: &mut String, depth: usize) -> LuaResult<()> {
+pub fn process_debug_values(result: &mut String, value: &LuaValue, depth: usize) -> LuaResult<()> {
     let left_padding = " ".repeat(2 * depth);
     match value {
         LuaValue::Table(t) => {
@@ -12,7 +12,7 @@ pub fn process_debug_values(value: LuaValue, result: &mut String, depth: usize) 
                 for pair in t.pairs::<LuaValue, LuaValue>() {
                     let (k, v) = pair?;
                     result.push_str(&format!("  {left_padding}{:#?} = ", k));
-                    process_debug_values(v, result, depth + 1)?;
+                    process_debug_values(result, &v, depth + 1)?;
                     result.push('\n');
                 }
                 result.push_str(&format!("{left_padding}}}"));
@@ -52,7 +52,7 @@ fn debug(luau: &Lua, stuff: LuaMultiValue) -> LuaResult<LuaString> {
     let mut multi_values = stuff.clone();
 
     while let Some(value) = multi_values.pop_front() {
-        process_debug_values(value, &mut result, 0)?;
+        process_debug_values(&mut result, &value, 0)?;
         if !multi_values.is_empty() {
             result += ", ";
         }

--- a/tests/luau/globals/output.luau
+++ b/tests/luau/globals/output.luau
@@ -110,6 +110,7 @@ print(vector.create(1, 2, 3))
 local array_with_many_values = {}; for i = 1, 1001 do table.insert(array_with_many_values, i) end
 -- print(array_with_many_values)
 
+local env = require("@std/env")
 local fs = require("@std/fs")
 
 local src = fs.readfile("./src/err.rs")
@@ -120,3 +121,25 @@ local with_newline_strings = {
 	src = src,
 }
 print(with_newline_strings)
+
+local cats2 = pp(cats)
+assert(typeof(cats2) == "table", "pp should return table when passed table")
+
+local cats3 = p(cats)
+assert(typeof(cats3) == "table", "p should return table when passed table")
+
+local buffy2 = buffer.create(12)
+buffer.writef32(buffy2, 0, 22.5)
+local buffy3 = dp(buffy2)
+assert(typeof(buffy3) == "buffer", "dp should return buffer when passed buffer")
+
+-- local badstr = "\x12, \x1b \27 \x12 \2 \33"
+
+local badstr = buffer.tostring(fs.readbytes(env.executable_path, 1, 400))
+
+print("below this should have utf8 replacement char")
+print(badstr)
+print("below this is dp output")
+dp(badstr)
+
+-- dp(format.pretty({ cats = badstr }))


### PR DESCRIPTION
There was a regression during a previous refactor resulting in those functions returning the formatted strings instead of their input value(s). there were not tests catching that. fixed and added tests