### PR TITLE
Implement env.arch

### DIFF
--- a/.seal/typedefs/std/env/init.luau
+++ b/.seal/typedefs/std/env/init.luau
@@ -5,8 +5,10 @@ export type env = {
     --- a list of arguments passed to the program
     args: { string },
     --- your operating system
-    os: "Windows" | "Linux" | "Android" | "MacOS" | "Other",
-    --- the path of the executable
+    os: "Windows" | "Linux" | "Android" | "MacOS" | string,
+    --- your system architecture, most likely `"x86_64"`
+    arch: ARCH,
+    --- path to the executable running your code; either *seal* itself or a compiled standalone version of *seal*.
     executable_path: string,
     --[=[ 
         Get the current working directory of the running process.
@@ -33,5 +35,28 @@ export type env = {
     -- removevar: (key: string) -> nil,
     vars: typeof(require("@self/vars"))
 }
+
+--- Your CPU processors' architecture; probably `"x86_64"`.
+export type ARCH = 
+    | "x86"
+    | "x86_64"
+    | "arm"
+    | "aarch64"
+    | "m68k"
+    | "mips"
+    | "mips32r6"
+    | "mips64"
+    | "mips64r6"
+    | "csky"
+    | "powerpc"
+    | "powerpc64"
+    | "riscv32"
+    | "riscv64"
+    | "s390x"
+    | "sparc"
+    | "sparc64"
+    | "hexagon"
+    | "loongarch32"
+    | "loongarch64"
 
 return {} :: env

--- a/docs/reference/std/env/init.md
+++ b/docs/reference/std/env/init.md
@@ -28,12 +28,26 @@ args: { string },
 <h4>
 
 ```luau
-os: "Windows" | "Linux" | "Android" | "MacOS" | "Other",
+os: "Windows" | "Linux" | "Android" | "MacOS" | string,
 ```
 
 </h4>
 
  your operating system
+
+---
+
+### env.arch
+
+<h4>
+
+```luau
+arch: ARCH,
+```
+
+</h4>
+
+ your system architecture, most likely `"x86_64"`
 
 ---
 
@@ -47,7 +61,7 @@ executable_path: string,
 
 </h4>
 
- the path of the executable
+ path to the executable running your code; either *seal* itself or a compiled standalone version of *seal*.
 
 ---
 
@@ -76,6 +90,140 @@ vars: typeof(require("@self/vars"))
 ```
 
 </h4>
+
+---
+
+## `export type` ARCH
+
+<h4>
+
+```luau
+export type ARCH =
+```
+
+</h4>
+
+ Your CPU processors' architecture; probably `"x86_64"`.
+
+---
+
+```luau
+| "x86"
+```
+
+---
+
+```luau
+| "x86_64"
+```
+
+---
+
+```luau
+| "arm"
+```
+
+---
+
+```luau
+| "aarch64"
+```
+
+---
+
+```luau
+| "m68k"
+```
+
+---
+
+```luau
+| "mips"
+```
+
+---
+
+```luau
+| "mips32r6"
+```
+
+---
+
+```luau
+| "mips64"
+```
+
+---
+
+```luau
+| "mips64r6"
+```
+
+---
+
+```luau
+| "csky"
+```
+
+---
+
+```luau
+| "powerpc"
+```
+
+---
+
+```luau
+| "powerpc64"
+```
+
+---
+
+```luau
+| "riscv32"
+```
+
+---
+
+```luau
+| "riscv64"
+```
+
+---
+
+```luau
+| "s390x"
+```
+
+---
+
+```luau
+| "sparc"
+```
+
+---
+
+```luau
+| "sparc64"
+```
+
+---
+
+```luau
+| "hexagon"
+```
+
+---
+
+```luau
+| "loongarch32"
+```
+
+---
+
+```luau
+| "loongarch64"
+```
 
 ---
 

--- a/src/std_env/mod.rs
+++ b/src/std_env/mod.rs
@@ -210,6 +210,7 @@ pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
 
     TableBuilder::create(luau)?
         .with_value("os", formatted_os)?
+        .with_value("arch", env::consts::ARCH)?
         .with_value("args", luau_args)?
         .with_value("executable_path", executable_path)?
         .with_value("shell_path", get_current_shell())?

--- a/tests/luau/std/env.luau
+++ b/tests/luau/std/env.luau
@@ -1,6 +1,13 @@
 local env = require("@std/env")
 local _vars = require("@std/env/vars")
 
+local function consts()
+    assert(env.os ~= nil, "we should have an env.os")
+    assert(env.arch ~= nil, "we should have an env.arch")
+end
+
+consts()
+
 local function iterate_args()
     for _, arg in env.args do
         print(arg)


### PR DESCRIPTION
Important for checking which architecture cdylib/plugins are meant for, i assume you should add that info in the shared object name.