### PR TITLE
Add prompt.edit and input.editline

### DIFF
--- a/.seal/typedefs/std/io/input.luau
+++ b/.seal/typedefs/std/io/input.luau
@@ -74,6 +74,31 @@ function input.readline(prompt: string): string | interrupt | error
 end
 
 --[=[
+    Prompts the user to edit one line of text, where the cursor is between the `left` and `right` strings.
+
+    If `right` is not provided, the user will start editing from the back of the message.
+
+    If a TTY is not detected, outputs `left .. "<CURSOR>" .. right`; the user/program will have
+    to respond with the full, edited message, not just the text to insert.
+
+    This function shares most semantics with `input.readline`, including the following:
+
+    ## Returns
+
+    - A `string` once the user types something in and presses <kbd>Enter</kbd>.
+    - An `interrupt` userdata, which contains a `code` (`"CtrlC"` or `"CtrlD"`) if the user presses either.
+    - An `error` userdata, if some other IO error occurs (like a broken pipe)
+
+    ## Errors
+
+    - *Throws* an error if some weird low level Errno code occurs or writing output to stdout fails.
+    
+]=]
+function input.editline(prompt: string, left: string, right: string?): string | interrupt | error
+    return nil :: any
+end
+
+--[=[
     Returns an `interrupt` userdata object. For reasons. Maybe control flow.
 ]=]
 function input.interrupt(key: "CtrlC" | "CtrlD"): interrupt

--- a/.seal/typedefs/std/io/prompt.luau
+++ b/.seal/typedefs/std/io/prompt.luau
@@ -45,6 +45,24 @@ export type prompt = {
     ]=]
     text: (message: string) -> string,
 
+    --[=[
+        Prompts the user to edit a prefilled line of text, with `left` being the string to the left
+        of the cursor, and `right` being the string to the right of the cursor if present.
+        
+        This function semantics of `input.editline`, except in that it throws an error if it encounters CtrlC, CtrlD,
+        or some other kind of IO issue.
+
+        - Like `prompt.text`, ": " will be added to the prompt if the prompt doesn't contain it already.
+
+        ## Usage
+
+        ```luau
+        local iso8601 = prompt.edit("end date", "2025-", "-12")
+        -- Displays "end date: 2025-<|>-12" where <|> is the text cursor
+        ```
+    ]=]
+    edit: (prompt: string, left: string, right: string?) -> string,
+
     --> prompt.confirm(message: string, default: boolean? (default true)): boolean
     --[=[
         Ask the user to confirm an action, defaulting to `true`, and displaying a y/n after the `message` prompt according to the usual CLI application conventions.

--- a/docs/reference/std/io/input.md
+++ b/docs/reference/std/io/input.md
@@ -118,6 +118,43 @@ end
 
 ---
 
+### input.editline
+
+<h4>
+
+```luau
+function input.editline(prompt: string, left: string, right: string?): string | interrupt | error
+```
+
+</h4>
+
+<details>
+
+<summary> See the docs </summary
+
+Prompts the user to edit one line of text, where the cursor is between the `left` and `right` strings.
+
+If `right` is not provided, the user will start editing from the back of the message.
+
+If a TTY is not detected, outputs `left .. "<CURSOR>" .. right`; the user/program will have
+to respond with the full, edited message, not just the text to insert.
+
+This function shares most semantics with `input.readline`, including the following:
+
+## Returns
+
+- A `string` once the user types something in and presses <kbd>Enter</kbd>.
+- An `interrupt` userdata, which contains a `code` (`"CtrlC"` or `"CtrlD"`) if the user presses either.
+- An `error` userdata, if some other IO error occurs (like a broken pipe)
+
+## Errors
+
+- *Throws* an error if some weird low level Errno code occurs or writing output to stdout fails.
+
+</details>
+
+---
+
 ### input.interrupt
 
 <h4>

--- a/docs/reference/std/io/prompt.md
+++ b/docs/reference/std/io/prompt.md
@@ -66,6 +66,39 @@ local ssn = prompt.text(colors.bold.white("whats your ssn???: "))
 
 ---
 
+### prompt.edit
+
+<h4>
+
+```luau
+function prompt.edit(prompt: string, left: string, right: string?) -> string,
+```
+
+</h4>
+
+<details>
+
+<summary> See the docs </summary
+
+Prompts the user to edit a prefilled line of text, with `left` being the string to the left
+of the cursor, and `right` being the string to the right of the cursor if present.
+
+This function semantics of `input.editline`, except in that it throws an error if it encounters CtrlC, CtrlD,
+or some other kind of IO issue.
+
+- Like `prompt.text`, ": " will be added to the prompt if the prompt doesn't contain it already.
+
+## Usage
+
+```luau
+local iso8601 = prompt.edit("end date", "2025-", "-12")
+-- Displays "end date: 2025-<|>-12" where <|> is the text cursor
+```
+
+</details>
+
+---
+
 ### prompt.confirm
 
 <h4>

--- a/tests/luau/std/io/prompts/edit_line.luau
+++ b/tests/luau/std/io/prompts/edit_line.luau
@@ -1,0 +1,11 @@
+local input = require("@std/io/input")
+local prompt = require("@std/io/prompt")
+
+local we_are = input.editline("", "We are the ")
+assert(we_are == "We are the dead", "we are the dead?")
+
+local middle = input.editline("put lived:", "short days ago we ", ", felt dawn")
+assert(middle == "short days ago we lived, felt dawn", "should type 'lived'")
+
+local resp = prompt.edit("What's your name?", "My name is", ".")
+assert(resp == "My name is deviaze.", "put deviaze lol")


### PR DESCRIPTION
Allows editing a prefilled line instead of users having to retype a whole line