### PR TITLE
Fix seal compile bugs

### DIFF
--- a/src/compile/bundle.luau
+++ b/src/compile/bundle.luau
@@ -272,8 +272,11 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
 
         -- it's a bash shebang used for running luau scripts as executables directly,
         -- hoist and move it to the top but don't include it here (or it syntax errors)
+        -- if a non-main file contains a bash shebang we also strip it to prevent syntax errors
         if line_number == 1 and str.startswith(line, "#!") then
-            bash_shebang = line
+            if depth == 0 then
+                bash_shebang = line
+            end 
             continue
         end
 
@@ -393,7 +396,9 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
             -- we want to pick the return with NO whitespace to the left, otherwise we may grab the wrong return
             if string.match(maybe_return_line, "^return%s+") then
                 -- modify dependency_lines in place to fix last return
-                dependency_lines[i] = string.gsub(maybe_return_line, "^return%s+", `local {identifier} = `)
+                -- this identifier should already be initialized from outside the do/end block,
+                -- so this is just assigning to an existing identifier
+                dependency_lines[i] = string.gsub(maybe_return_line, "^return%s+", `{identifier} = `)
                 return_replaced = true
                 break
             end
@@ -407,6 +412,8 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
         -- and simply add all dependency lines to transformed
         table.insert(transformed, `-- START {resolved.path}`)
         
+        -- add identifier for return to be transformed into an assignment to
+        table.insert(transformed, `local {identifier}`)
         -- wrap entire thing in a do/end block so we don't hit the 200 locals limit
         table.insert(transformed, "do")
         for _, dependency_line in dependency_lines do

--- a/src/compile/bundle.luau
+++ b/src/compile/bundle.luau
@@ -170,7 +170,7 @@ local function transform_thread_spawn_path(
     line_number: number,
     path: string,
     --- recursive handle to function calling this function cause uh yeah
-    traverse: (path: string, depth: number?, seen_stdlibs: { [string]: boolean? }?) -> err.Result<{string}>,
+    traverse: (path: string, depth: number?, seen_stdlibs: { [string]: string? }?) -> err.Result<{string}>,
     depth: number
 ): err.Result<{string}>
     local relative_path = string.match(line, [=[path%s*=%s*["']([^"']+)["']]=])
@@ -212,9 +212,9 @@ end
 local anon_identifier = 0
 
 local seen: { [string]: string? } = {}
-local default_seen_stdlibs: { [string]: boolean? } = {}
+local default_seen_stdlibs: { [string]: string? } = {}
 
-local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: boolean? }?): err.Result<{string}>
+local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: string? }?): err.Result<{string}>
     seen_stdlibs = seen_stdlibs or default_seen_stdlibs
     depth = depth or 0
 
@@ -245,7 +245,6 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
         )
     end
 
-    -- this shouldn't error as path is checked by get_entry_path or require resolver
     local file = fs.file.from(path) 
     if not file:is_valid_utf8() then
         return err.message(`file at '{path}' is not valid utf-8 ☠️`)
@@ -290,9 +289,14 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
         end
 
         -- if it's requiring a seal stdlib, check if we've already required it, and only add the line if we haven't yet
+        -- FIXME: this will absolutely break when the first identifier for the stdlib isn't defined in top scope
         if str.starts(requested_require, table.unpack(reserved_aliases)) then
             if not seen_stdlibs[requested_require] then
-                seen_stdlibs[requested_require] = true
+                seen_stdlibs[requested_require] = identifier
+                append(line)
+            elseif seen_stdlibs[requested_require] ~= identifier then
+                -- the standard library was bound to a different identifier this time, 
+                -- just add it anyway to stop bugs
                 append(line)
             end
             continue

--- a/src/compile/bundle.luau
+++ b/src/compile/bundle.luau
@@ -209,13 +209,27 @@ local function transform_thread_spawn_path(
     return result
 end
 
+local function get_reserved_identifier(path: string): string
+    -- @std/fs -> standard_library_std_fs
+    -- @std/io/input -> standard_library_std_io_input
+    -- @interop/mlua -> standard_library_interop_mlua
+    local stripped = string.sub(path, 2) -- strip leading "@"
+    return "standard_library_" .. string.gsub(stripped, "/", "_")
+end
+
 local anon_identifier = 0
 
 local seen: { [string]: string? } = {}
-local default_seen_stdlibs: { [string]: string? } = {}
+local bash_shebang: string? = nil
+--- maps reserved-alias identifier -> original require path, accumulated across all traversals
+local hoisted_stdlib_requires: { [string]: string } = {}
 
 local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: string? }?): err.Result<{string}>
-    seen_stdlibs = seen_stdlibs or default_seen_stdlibs
+    -- when seen_stdlibs is nil we're in a top-level traversal and hoist stdlib requires to bundle top;
+    -- when it's explicitly provided (e.g. {} for thread.spawn inlining) stdlib requires stay inline
+    local should_hoist_stdlibs = seen_stdlibs == nil
+
+    seen_stdlibs = seen_stdlibs or {}
     depth = depth or 0
 
     if depth > 333 then
@@ -256,6 +270,13 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
             continue
         end
 
+        -- it's a bash shebang used for running luau scripts as executables directly,
+        -- hoist and move it to the top but don't include it here (or it syntax errors)
+        if line_number == 1 and str.startswith(line, "#!") then
+            bash_shebang = line
+            continue
+        end
+
         local identifier, requested_require = extract_identifier_and_path(line, `{path}:{line_number}`)
         if typeof(identifier) == "error" then
             return identifier
@@ -288,16 +309,27 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
             continue
         end
 
-        -- if it's requiring a seal stdlib, check if we've already required it, and only add the line if we haven't yet
-        -- FIXME: this will absolutely break when the first identifier for the stdlib isn't defined in top scope
         if str.starts(requested_require, table.unpack(reserved_aliases)) then
-            if not seen_stdlibs[requested_require] then
-                seen_stdlibs[requested_require] = identifier
+            if should_hoist_stdlibs then
+                -- replace the require call with the deterministic stdlib identifier and hoist the actual require to the top
+                local library_identifier = get_reserved_identifier(requested_require)
+                hoisted_stdlib_requires[library_identifier] = requested_require
+
+                local replace_parens_pattern = 'require%s*%(%s*["\']' .. requested_require .. '["\']%s*%)'
+                line = string.gsub(line, replace_parens_pattern, library_identifier)
+
+                local replace_string_call_pattern = 'require%s*["\']' .. requested_require .. '["\']'
+                line = string.gsub(line, replace_string_call_pattern, library_identifier)
                 append(line)
-            elseif seen_stdlibs[requested_require] ~= identifier then
-                -- the standard library was bound to a different identifier this time, 
-                -- just add it anyway to stop bugs
-                append(line)
+            else
+                -- thread.spawn inlining: stdlib requires stay inline so the spawned code is self-contained
+                if not seen_stdlibs[requested_require] then
+                    seen_stdlibs[requested_require] = identifier
+                    append(line)
+                elseif seen_stdlibs[requested_require] ~= identifier then
+                    -- identifier was renamed, inline the require anyway to prevent bugs
+                    append(line)
+                end
             end
             continue
         end
@@ -374,9 +406,13 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
 
         -- and simply add all dependency lines to transformed
         table.insert(transformed, `-- START {resolved.path}`)
+        
+        -- wrap entire thing in a do/end block so we don't hit the 200 locals limit
+        table.insert(transformed, "do")
         for _, dependency_line in dependency_lines do
-            append(dependency_line)
+            append("    " .. dependency_line)
         end
+        table.insert(transformed, "end")
 
         -- replace the require call with the identifier name
         local replace_parens_pattern = 'require%s*%(%s*["\']' .. requested_require .. '["\']%s*%)'
@@ -404,8 +440,23 @@ local function bundle(project_path: string): err.Result<string>
         return bundled_lines
     end
 
+    local stdlib_lines: { string } = {}
+    for library_identifier, library_require_path in hoisted_stdlib_requires do
+        table.insert(stdlib_lines, `local {library_identifier} = require("{library_require_path}")`)
+    end
+    -- sort stdlibs for deterministic output order
+    table.sort(stdlib_lines)
+
+    for i = #stdlib_lines, 1, -1 do
+        table.insert(bundled_lines, 1, stdlib_lines[i])
+    end
+
     for hot_comment, _ in hot_comments do
         table.insert(bundled_lines, 1, hot_comment)
+    end
+
+    if bash_shebang then
+        table.insert(bundled_lines, 1, bash_shebang)
     end
 
     local bundled = table.concat(bundled_lines, "\n")

--- a/src/compile/bundle.luau
+++ b/src/compile/bundle.luau
@@ -244,8 +244,14 @@ local function traverse(path: string, depth: number?, seen_stdlibs: { [string]: 
             find_plain(line, first) and find_plain(line, second)
         )
     end
+
+    -- this shouldn't error as path is checked by get_entry_path or require resolver
+    local file = fs.file.from(path) 
+    if not file:is_valid_utf8() then
+        return err.message(`file at '{path}' is not valid utf-8 ☠️`)
+    end
     
-    for line_number, line in fs.readlines(path) do
+    for line_number, line in file:readlines() do
         is_comment, comment_prefix = comment(line, comment_prefix)
         if is_comment then
             continue

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,7 +406,7 @@ fn seal_compile(args: Args) -> LuauLoadResult {
     #[allow(unused_mut, reason = "needs to be mut on windows")]
     let CompileOptions { entry_path, mut output_path } = CompileOptions::from_args(args)?;
 
-    let bundled_src = compile::bundle(&entry_path)?;
+    let mut bundled_src = compile::bundle(&entry_path)?;
 
     if output_path.ends_with(".luau") {
         match fs::write(&output_path, bundled_src) {
@@ -419,6 +419,11 @@ fn seal_compile(args: Args) -> LuauLoadResult {
         }
         return Ok(None);
     };
+
+    // handle shebangs by stripping first line from \n
+    if bundled_src.starts_with("#!") && let Some(first_newline_pos) = bundled_src.find('\n') {
+        bundled_src = bundled_src[first_newline_pos + 1..].to_string();
+    }
 
     let compiled_standalone_bytes = compile::standalone(&bundled_src)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,56 +320,91 @@ fn seal_regen() -> LuauLoadResult {
     Ok(None)
 }
 
-fn seal_compile(mut args: Args) -> LuauLoadResult {
+struct CompileOptions {
+    entry_path: String,
+    output_path: String,
+}
+impl CompileOptions {
+    /// valid inputs:
+    /// `seal compile` - no args, compiles to binary executable named after parent directory
+    /// `seal compile filename.luau` - entry path is filename.luau, compiles to binary executable named after parent directory
+    /// `seal compile -o bin(.luau)` - input file is default, output file is bin(.luau)
+    /// `seal compile filename.luau -o bin(.luau)` - input file is filename.luau, output file is bin(.luau)  
+    fn from_args(mut args: Args) -> LuaResult<Self> {
+        let function_name = "seal compile";
+
+        let default_entry_path = std_env::get_cwd(function_name)?;
+        let default_output_path = match default_entry_path.file_name() {
+            Some(basename) => basename.to_string_lossy(),
+            None => {
+                return wrap_err!("{} - why can't we figure out the basename of your cwd???", function_name);
+            }
+        };
+        
+        // seal compile (no args)
+        if args.is_empty() {
+            return Ok(Self {
+                entry_path: default_entry_path.to_string_lossy().into_owned(),
+                output_path: default_output_path.to_string()
+            });
+        }
+
+        fn get(args: &mut Args, count: i32) -> LuaResult<Option<String>> {
+            match args.pop_front() {
+                None => Ok(None),
+                Some(arg) => match arg.into_string() {
+                    Ok(s) => Ok(Some(s)),
+                    Err(_) => {
+                        wrap_err!("seal compile - argument number {} contains invalid utf-8 ☠️", count)
+                    }
+                }
+            }
+        }
+
+        // we can have up to 3 strings we need to pop
+        let first = get(&mut args, 1)?;
+        let second = get(&mut args, 2)?;
+        let third = get(&mut args, 3)?;
+
+        let options = match (first.as_deref(), second.as_deref(), third.as_deref()) {
+            (Some("-o"), Some(output_path), None) => {
+                Self {
+                    entry_path: default_entry_path.to_string_lossy().into_owned(),
+                    output_path: output_path.to_owned()
+                }
+            },
+            (Some("-o"), None, None) => {
+                return wrap_err!("{} - output switch (-o) provided but missing output file name/path", function_name);
+            },
+            (Some(entry_path), None, None) => {
+                Self {
+                    entry_path: entry_path.to_string(),
+                    output_path: default_output_path.to_string()
+                }
+            },
+            (Some(entry_path), Some("-o"), Some(output_path)) => {
+                Self {
+                    entry_path: entry_path.to_string(),
+                    output_path: output_path.to_string()
+                }
+            },
+            (Some(_entry_path), Some("-o"), None) => {
+                return wrap_err!("{} - entry path and output switch (-o) provided but missing output file name/path", function_name);
+            },
+            (first, second, third) => {
+                return wrap_err!("{} - invalid combination of options detected, expected <no options> or <entry path> or <entry path> -o <output path>, got: {:?} {:?} {:?}", function_name, first, second, third);
+            }
+        };
+
+        Ok(options)
+    }
+}
+
+fn seal_compile(args: Args) -> LuauLoadResult {
     let function_name = "seal compile";
 
-    let default_entry_path = std_env::get_cwd(function_name)?;
-    let default_output_path = match default_entry_path.file_name() {
-        Some(basename) => basename.to_string_lossy(),
-        None => {
-            return wrap_err!("{} - why can't we figure out the basename of your cwd???", function_name);
-        }
-    };
-
-    // ugly asf we should probably be parsing these in SealCommand
     #[allow(unused_mut, reason = "needs to be mut on windows")]
-    let (entry_path, mut output_path): (String, String) = {
-        if args.is_empty() {
-            (default_entry_path.to_string_lossy().to_string(), default_output_path.to_string())
-        } else if let Some(front) = args.front()
-            && let Some(front) = front.to_str()
-        {
-            if front == "-o" {
-                let _ = args.pop_front();
-                if let Some(exec_name) = args.front() {
-                    (default_entry_path.to_string_lossy().to_string(), exec_name.to_string_lossy().to_string())
-                } else {
-                    return wrap_err!("{} - output switch (-o) provided but missing output file name/path", function_name);
-                }
-            } else {
-                let entry_path = args.pop_front().expect("args cannot be empty here");
-                if let Some(front) = args.front()
-                    && let Some(front) = front.to_str()
-                {
-                    if front == "-o" {
-                        let _ = args.pop_front();
-                        if let Some(exec_name) = args.front() {
-                            (entry_path.to_string_lossy().to_string(), exec_name.to_string_lossy().to_string())
-                        } else {
-                            return wrap_err!("{} - output switch (-o) provided but missing output file name/path", function_name);
-                        }
-                    } else {
-                        (entry_path.to_string_lossy().to_string(), default_output_path.to_string())
-                    }
-                } else {
-                    return wrap_err!("{} - bad utf8 :skull:", function_name);
-                }
-
-            }
-        } else {
-            return wrap_err!("{} - bad utf8 :skull:", function_name);
-        }
-    };
+    let CompileOptions { entry_path, mut output_path } = CompileOptions::from_args(args)?;
 
     let bundled_src = compile::bundle(&entry_path)?;
 


### PR DESCRIPTION
- Rewrites the ugly `seal compile` options parsing logic with one that actually works.
- Fixes a panic when a file path of a file containing invalid utf8 is passed to the first argument of `seal compile`
- Keep track of and hoist standard library requires to top of file, transforming all requires of standard libraries to refer to those unique identifiers instead
- Enclose all dependencies in `do/end` blocks so we don't hit the 200 locals limit in larger codebases and so we don't leak top level locals.
- Keeps track of shell shebangs and when detected puts them on top of bundled `.luau` files. But correctly strips the shebang when a `.luau` file containing a shebang is passed to `seal compile` to be compiled into a standalone executable.