### PR TITLE
Fix incorrect `require()` behavior.

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -13,7 +13,7 @@
     
     // these are for testing in `aliases.luau`
     "redundant": "./.seal/extra/tt.luau",
-    "redundant-but-dir": "./.seal/extra/newdir.luau", // this will be generated
-    "seal.gamertag-epic_swag-hina-_seal.level-69420_1337.requires-tests.data_directory": "./tests/data/"
+    "redundant-but-dir": "./tests/data/newdir.luau", // this will be generated
+    "seal.gamertag-epic_swag-hina-_seal.LEVEL-69420_1337.requires-tests.data_directory": "./tests/data/"
   }
 }

--- a/.luaurc
+++ b/.luaurc
@@ -11,8 +11,6 @@
     "tests": "./tests/",
     "data": "./tests/data/",
     
-    "seal-std": "./.seal/typedefs/std/", // this is for testing in `basic_requires.luau`
-    "seal.std": "./.seal/typedefs/std/", // this is for testing in `basic_requires.luau`
-    "seal-std.seal.gamertag-epic-swag.fun": "./.seal/typedefs/std/" // this is for testing in `basic_requires.luau`
+    "seal.gamertag-epic_swag-hina-_seal.level-69420_1337.requires-tests.data_directory": "./tests/data/" // this is for testing in `aliases.luau`
   }
 }

--- a/.luaurc
+++ b/.luaurc
@@ -6,11 +6,14 @@
   "aliases": {
     "std": "./.seal/typedefs/std/",
     "interop": "./.seal/typedefs/interop/",
-    "output_formatter": "./src/std_io/output_formatter.luau",
+    "output_formatter": "./src/std_io/output_formatter",
     "extra": "./.seal/extra/",
     "tests": "./tests/",
     "data": "./tests/data/",
     
-    "seal.gamertag-epic_swag-hina-_seal.level-69420_1337.requires-tests.data_directory": "./tests/data/" // this is for testing in `aliases.luau`
+    // these are for testing in `aliases.luau`
+    "redundant": "./.seal/extra/tt.luau",
+    "redundant-but-dir": "./.seal/extra/newdir.luau", // this will be generated
+    "seal.gamertag-epic_swag-hina-_seal.level-69420_1337.requires-tests.data_directory": "./tests/data/"
   }
 }

--- a/.luaurc
+++ b/.luaurc
@@ -9,6 +9,10 @@
     "output_formatter": "./src/std_io/output_formatter.luau",
     "extra": "./.seal/extra/",
     "tests": "./tests/",
-    "data": "./tests/data/"
+    "data": "./tests/data/",
+    
+    "seal-std": "./.seal/typedefs/std/", // this is for testing in `basic_requires.luau`
+    "seal.std": "./.seal/typedefs/std/", // this is for testing in `basic_requires.luau`
+    "seal-std.seal.gamertag-epic-swag.fun": "./.seal/typedefs/std/" // this is for testing in `basic_requires.luau`
   }
 }

--- a/src/require/resolver.luau
+++ b/src/require/resolver.luau
@@ -139,6 +139,10 @@ local function expand_aliases(requested_path: string, aliases_by_luaurc: { Luaur
 			rest_of_path = string.sub(rest_of_path, 2, #rest_of_path)
 		end
 		
+		if alias_replacement:sub(-5, -1) == ".luau" and fs.is(alias_replacement) == "File" then
+			return nil, `alias replacement {alias_replacement} is a file and has redundant \`.luau\` file extension. please remove it :3`
+		end
+		
 		local alias_with_luau = alias_replacement .. ".luau"
 		if fs.is(alias_with_luau) == "File" then
 			return alias_with_luau, nil

--- a/src/require/resolver.luau
+++ b/src/require/resolver.luau
@@ -112,7 +112,7 @@ end
 -- returns the expanded current_path with a replacement found from a .luaurc if one exists
 -- if there's an error, the second return will be an error message
 local function expand_aliases(requested_path: string, aliases_by_luaurc: { LuaurcAliases }): (string?, string?)
-	local extracted_alias = string.match(requested_path, "^@([%w_]+)/?")
+	local extracted_alias = string.match(requested_path, "^@([%w_%-%.]+)/?")
 	if not extracted_alias then
 		return nil, `couldn't extract require alias from requested path '{requested_path}'; is it a valid alias (like "@alias/path" or "@alias")?`
 	end
@@ -196,7 +196,7 @@ local function resolve(
 		note that seal supports @self in either case
 	]]
 ): RequireResolveResult
-local debug_name: string = override_debug_name or debug.info(3, "s") --[[ 
+	local debug_name: string = override_debug_name or debug.info(3, "s") --[[ 
 	this should give us the 
 	debug name (set by luau.load().set_name) for the chunk that called require(),
 	in the format `[string "./src/somewhere.luau"]`

--- a/src/require/resolver.luau
+++ b/src/require/resolver.luau
@@ -132,17 +132,18 @@ local function expand_aliases(requested_path: string, aliases_by_luaurc: { Luaur
 	end
 	
 	if alias_replacement then
-		-- special case @file aliases
-		if str.endswith(alias_replacement, ".luau") then
-			return alias_replacement, nil
-		end
-
 		local rest_of_path = requested_path
 		-- strip @alias prefix
 		rest_of_path = string.sub(rest_of_path, #extracted_alias + 2, #rest_of_path)
 		if str.startswith(rest_of_path, "/") then
 			rest_of_path = string.sub(rest_of_path, 2, #rest_of_path)
 		end
+		
+		local alias_with_luau = alias_replacement .. ".luau"
+		if fs.is(alias_with_luau) == "File" then
+			return alias_with_luau, nil
+		end
+		
 		if not str.endswith(alias_replacement, "/") then
 			alias_replacement ..= "/"
 		end

--- a/src/require/resolver.luau
+++ b/src/require/resolver.luau
@@ -139,8 +139,9 @@ local function expand_aliases(requested_path: string, aliases_by_luaurc: { Luaur
 			rest_of_path = string.sub(rest_of_path, 2, #rest_of_path)
 		end
 		
-		if alias_replacement:sub(-5, -1) == ".luau" and fs.is(alias_replacement) == "File" then
-			return nil, `alias replacement {alias_replacement} is a file and has redundant \`.luau\` file extension. please remove it :3`
+		-- check for file because specs allow directory to have the extension
+		if string.sub(alias_replacement, -5, -1) == ".luau" and fs.is(alias_replacement) == "File" then
+			return nil, `seal no longer allows require alias replacements to contain \`.luau\` file extensions (got {alias_replacement}); please remove the file extension to stay in spec :3`
 		end
 		
 		local alias_with_luau = alias_replacement .. ".luau"

--- a/tests/luau/globals/require/aliases.luau
+++ b/tests/luau/globals/require/aliases.luau
@@ -55,23 +55,22 @@ local function aliaswithfullnamespecs()
 	local data_dir = fs.dir.from(data_path)
 		:add_file("init.luau", "return 'successful'")
 	
-	local res = (require)("@seal.gamertag-epic_swag-hina-_seal.level-69420_1337.requires-tests.data_directory")
-	assert(res == "successful", "requiring with full alias name specs failed. please double-check impl or alias")
+	local res = (require)("@seal.gamertag-epic_swag-hina-_seal.LEVEL-69420_1337.requires-tests.data_directory")
 	fs.removefile(data_dir:join("init.luau"))
+	assert(res == "successful", "requiring with full alias name specs failed. please double-check impl or alias")
 end
 
 aliaswithfullnamespecs()
 
-local function aliaswithredundantfileextension()
+local function aliaswithredundantext()
 	local s, f = pcall(function()
 		require("@redundant")
 		return nil
 	end)
 	assert(s == false, "this should not work - alias path to file cannot have redundant `.luau`. should only work when it is a directory")
 	assert(format.uncolor(tostring(f)):match("`.luau` file extensions %(got [%w_%-%./]+%); please remove the file extension to stay in spec"), "inconsistent error message")
-	-- FIXME: missing assertion for expected error message (not impl yet)
 	
-	local path = fs.path.join(".", ".seal", "extra")
+	local path = fs.path.join(".", "tests", "data")
 	local newdir_path = fs.path.join(path, "newdir.luau")
 	local newdir = fs.tree()
 			:with_file("init.luau", "return \"successful\"")
@@ -87,4 +86,4 @@ local function aliaswithredundantfileextension()
 	assert(rawequal(f2, "successful"), "incorrectly required directory")
 end
 
-aliaswithredundantfileextension()
+aliaswithredundantext()

--- a/tests/luau/globals/require/aliases.luau
+++ b/tests/luau/globals/require/aliases.luau
@@ -49,3 +49,15 @@ local function aliaswithoutslashdir()
 end
 
 aliaswithoutslashdir()
+
+local function aliaswithfullnamespecs()
+	local data_path = fs.path.join(".", "tests", "data")
+	local data_dir = fs.dir.from(data_path)
+		:add_file("init.luau", "return 'successful'")
+	
+	local res = (require)("@seal.gamertag-epic_swag-hina-_seal.level-69420_1337.requires-tests.data_directory")
+	assert(res == "successful", "requiring with full alias name specs failed. please double-check impl or alias")
+	fs.removefile(data_dir:join("init.luau"))
+end
+
+aliaswithfullnamespecs()

--- a/tests/luau/globals/require/aliases.luau
+++ b/tests/luau/globals/require/aliases.luau
@@ -68,6 +68,7 @@ local function aliaswithredundantfileextension()
 		return nil
 	end)
 	assert(s == false, "this should not work - alias path to file cannot have redundant `.luau`. should only work when it is a directory")
+	assert(format.uncolor(tostring(f)):match("redundant `.luau` file extension. please remove it :3"), "inconsistent error message")
 	-- FIXME: missing assertion for expected error message (not impl yet)
 	
 	local path = fs.path.join(".", ".seal", "extra")

--- a/tests/luau/globals/require/aliases.luau
+++ b/tests/luau/globals/require/aliases.luau
@@ -68,7 +68,7 @@ local function aliaswithredundantfileextension()
 		return nil
 	end)
 	assert(s == false, "this should not work - alias path to file cannot have redundant `.luau`. should only work when it is a directory")
-	assert(format.uncolor(tostring(f)):match("redundant `.luau` file extension. please remove it :3"), "inconsistent error message")
+	assert(format.uncolor(tostring(f)):match("`.luau` file extensions %(got [%w_%-%./]+%); please remove the file extension to stay in spec"), "inconsistent error message")
 	-- FIXME: missing assertion for expected error message (not impl yet)
 	
 	local path = fs.path.join(".", ".seal", "extra")

--- a/tests/luau/globals/require/aliases.luau
+++ b/tests/luau/globals/require/aliases.luau
@@ -61,3 +61,29 @@ local function aliaswithfullnamespecs()
 end
 
 aliaswithfullnamespecs()
+
+local function aliaswithredundantfileextension()
+	local s, f = pcall(function()
+		require("@redundant")
+		return nil
+	end)
+	assert(s == false, "this should not work - alias path to file cannot have redundant `.luau`. should only work when it is a directory")
+	-- FIXME: missing assertion for expected error message (not impl yet)
+	
+	local path = fs.path.join(".", ".seal", "extra")
+	local newdir_path = fs.path.join(path, "newdir.luau")
+	local newdir = fs.tree()
+			:with_file("init.luau", "return \"successful\"")
+			:with_file("main.luau", "return \"failure\"")
+	fs.writetree(newdir_path, newdir)
+	
+	local s2, f2 = pcall(function()
+		return (require)("@redundant-but-dir")
+	end)
+	fs.removetree(newdir_path)
+	
+	assert(s2 == true, "this should work - alias path to directory can have redundant `.luau`")
+	assert(rawequal(f2, "successful"), "incorrectly required directory")
+end
+
+aliaswithredundantfileextension()

--- a/tests/luau/globals/require/aliases.luau
+++ b/tests/luau/globals/require/aliases.luau
@@ -68,7 +68,7 @@ local function aliaswithredundantext()
 		return nil
 	end)
 	assert(s == false, "this should not work - alias path to file cannot have redundant `.luau`. should only work when it is a directory")
-	assert(format.uncolor(tostring(f)):match("`.luau` file extensions %(got [%w_%-%./]+%); please remove the file extension to stay in spec"), "inconsistent error message")
+	assert(format.uncolor(tostring(f)):match("please remove the file extension to stay in spec"), "inconsistent error message")
 	
 	local path = fs.path.join(".", "tests", "data")
 	local newdir_path = fs.path.join(path, "newdir.luau")

--- a/tests/luau/globals/require/basic-requires/basic_requires.luau
+++ b/tests/luau/globals/require/basic-requires/basic_requires.luau
@@ -132,34 +132,4 @@ end
 
 filethaterrors()
 
-local function aliaswithdash()
-	local std = require("@seal-std")
-	assert(std, "require alias not working with dash (-)")
-	
-	local io = require("@seal-std/io")
-	assert(io, "require alias not working with dash (-) to a submodule")
-end
-
-aliaswithdash()
-
-local function aliaswithperiod()
-	local std = require("@seal.std")
-	assert(std, "require alias not working with period (.)")
-	
-	local io = require("@seal.std/io")
-	assert(io, "require alias not working with period (.) to a submodule")
-end
-
-aliaswithperiod()
-
-local function aliaswithdashandperiod()
-	local std = require("@seal-std.seal.gamertag-epic-swag.fun")
-	assert(std, "require alias not working with dash (-) and period (-)")
-	
-	local io = require("@seal-std.seal.gamertag-epic-swag.fun/io")
-	assert(io, "require alias not working with dash (-) and period (.) to a submodule")
-end
-
-aliaswithdashandperiod()
-
 return {}

--- a/tests/luau/globals/require/basic-requires/basic_requires.luau
+++ b/tests/luau/globals/require/basic-requires/basic_requires.luau
@@ -132,4 +132,34 @@ end
 
 filethaterrors()
 
+local function aliaswithdash()
+	local std = require("@seal-std")
+	assert(std, "require alias not working with dash (-)")
+	
+	local io = require("@seal-std/io")
+	assert(io, "require alias not working with dash (-) to a submodule")
+end
+
+aliaswithdash()
+
+local function aliaswithperiod()
+	local std = require("@seal.std")
+	assert(std, "require alias not working with period (.)")
+	
+	local io = require("@seal.std/io")
+	assert(io, "require alias not working with period (.) to a submodule")
+end
+
+aliaswithperiod()
+
+local function aliaswithdashandperiod()
+	local std = require("@seal-std.seal.gamertag-epic-swag.fun")
+	assert(std, "require alias not working with dash (-) and period (-)")
+	
+	local io = require("@seal-std.seal.gamertag-epic-swag.fun/io")
+	assert(io, "require alias not working with dash (-) and period (.) to a submodule")
+end
+
+aliaswithdashandperiod()
+
 return {}


### PR DESCRIPTION
This pull request fixes incorrect `require()` behavior. It wasn't following the specs properly.

Changes include capturing more symbols (`-` and `.`) and disallowing redundant `.luau` for files in aliases.

Added test cases for both changes and another test case for a directory ending in `.luau` with a `init.luau`.

Resolves #190, #191.
Closes #190
Closes #191