### PR TITLE
Pass custom globals to luau.eval

### DIFF
--- a/.seal/typedefs/std/luau/init.luau
+++ b/.seal/typedefs/std/luau/init.luau
@@ -3,18 +3,21 @@ export type luau = {
     --[=[
         Evaluate Luau source code from a string in the current Luau VM.
 
-        By default, this function evaluates in `"safe"` mode with only Luau's standard library (minus some deprecated environment breaking functions).
+        By default, this function evaluates in `"Safe"` mode with only Luau's standard library (minus some deprecated environment breaking functions).
 
         ### `EvalOptions` options:
 
         `name` represents the `chunk_name` of the evaluated src.
 
-        `stdlib` can be one of the following (or left unspecified, in which it defaults to `"safe"`):
+        `stdlib` can be one of the following (or left unspecified, in which it defaults to `"Safe"`):
 
-        - `"safe"` - The evaled code will have access to most libraries/functions that come with Luau, 
+        - `"Safe"` - The evaled code will have access to most libraries/functions that come with Luau, 
             but nothing that can access your file system or the internet.
-        - `"seal"` - The evaled code will have access to anything seal can do, from accessing environment variables to creating an infinite number of empty files in your home directory.
-        - `"none"` - Disable every single global Luau comes with, including `tostring` and `print`.
+        - `"Seal"` - The evaled code will have access to anything seal can do, from accessing environment variables to creating an infinite number of empty files in your home directory.
+        - `"None"` - Disable every single global Luau comes with, including `tostring` and `print`.
+
+        `globals` adds adds additional functions/variables to the environment; all globals are added to the standard set
+        of Luau and seal globals provided by your choice of `stdlib`.
 
         ## Returns
 
@@ -23,6 +26,7 @@ export type luau = {
 
         ## Errors
         - if the code cannot be evaluated, but not if it contains a syntax error or errors at runtime.
+        - if any key in the table passed to `options.globals` is not a string
 
         ## Usage
 
@@ -70,8 +74,12 @@ export type luau = {
 }
 
 export type EvalOptions = {
+    --- the chunk_name of the code to be evaluated
     name: string?,
-    stdlib: ("seal" | "safe" | "none")?,
+    --- the base set of globals to include; case-insensitive for backwards compatibility.
+    stdlib: ("Seal" | "Safe" | "None")?,
+    --- add additional globals to the environment, including functions and variables.
+    globals: { [string]: any }?,
 }
 
 export type LuaurcAliases = {

--- a/docs/reference/std/luau/init.md
+++ b/docs/reference/std/luau/init.md
@@ -23,18 +23,21 @@ function luau.eval(src: string, options: EvalOptions?) -> unknown | error,
 
 Evaluate Luau source code from a string in the current Luau VM.
 
-By default, this function evaluates in `"safe"` mode with only Luau's standard library (minus some deprecated environment breaking functions).
+By default, this function evaluates in `"Safe"` mode with only Luau's standard library (minus some deprecated environment breaking functions).
 
 ### `EvalOptions` options
 
 `name` represents the `chunk_name` of the evaluated src.
 
-`stdlib` can be one of the following (or left unspecified, in which it defaults to `"safe"`):
+`stdlib` can be one of the following (or left unspecified, in which it defaults to `"Safe"`):
 
-- `"safe"` - The evaled code will have access to most libraries/functions that come with Luau,
+- `"Safe"` - The evaled code will have access to most libraries/functions that come with Luau,
 but nothing that can access your file system or the internet.
-- `"seal"` - The evaled code will have access to anything seal can do, from accessing environment variables to creating an infinite number of empty files in your home directory.
-- `"none"` - Disable every single global Luau comes with, including `tostring` and `print`.
+- `"Seal"` - The evaled code will have access to anything seal can do, from accessing environment variables to creating an infinite number of empty files in your home directory.
+- `"None"` - Disable every single global Luau comes with, including `tostring` and `print`.
+
+`globals` adds adds additional functions/variables to the environment; all globals are added to the standard set
+of Luau and seal globals provided by your choice of `stdlib`.
 
 ## Returns
 
@@ -44,6 +47,7 @@ an error that occurred when evaluating the code, such as a syntax error or runti
 ## Errors
 
 - if the code cannot be evaluated, but not if it contains a syntax error or errors at runtime.
+- if any key in the table passed to `options.globals` is not a string
 
 ## Usage
 
@@ -179,6 +183,8 @@ name: string?,
 
 </h4>
 
+ the chunk_name of the code to be evaluated
+
 ---
 
 ### EvalOptions.stdlib
@@ -186,10 +192,26 @@ name: string?,
 <h4>
 
 ```luau
-function EvalOptions.stdlib("seal" | "safe" | "none")?,
+function EvalOptions.stdlib("Seal" | "Safe" | "None")?,
 ```
 
 </h4>
+
+ the base set of globals to include; case-insensitive for backwards compatibility.
+
+---
+
+### EvalOptions.globals
+
+<h4>
+
+```luau
+globals: { [string]: any }?,
+```
+
+</h4>
+
+ add additional globals to the environment, including functions and variables.
 
 ---
 

--- a/src/setup/setup.luau
+++ b/src/setup/setup.luau
@@ -356,7 +356,7 @@ end
 function should_replace_typedefs(config_luau: fs.FileEntry)
     local function slightly_safe_eval(path: string): { seal_version: string? }
         local src = fs.readfile(path)
-        local res = luau.eval(src, { stdlib = "seal" }) -- allow seal stdlib in case test functions or smth need it
+        local res = luau.eval(src, { stdlib = "Seal" }) -- allow seal stdlib in case test functions or smth need it
         if typeof(res) == "error" then
             err(`Error reading your config.luau file at {path}: {res}`)
             error("unreachable")

--- a/src/std_luau/mod.rs
+++ b/src/std_luau/mod.rs
@@ -3,8 +3,6 @@ use crate::{Chunk, prelude::*};
 
 use mluau::Compiler;
 
-// TODO: lute support
-
 struct EvalError {
     message: String,
 }
@@ -35,16 +33,18 @@ enum EvalStdlib {
 struct EvalOptions {
     name: Option<String>,
     stdlib: EvalStdlib,
+    globals: Option<LuaTable>,
 }
 impl EvalOptions {
     fn default() -> Self {
         EvalOptions {
             name: None,
             stdlib: EvalStdlib::Safe,
+            globals: None,
         }
     }
 
-    fn from_value(value: LuaValue, function_name: &'static str) -> LuaResult<Self> {
+    fn from_table(value: LuaValue, function_name: &'static str) -> LuaResult<Self> {
         let t = match value {
             LuaValue::Table(t) => Some(t),
             LuaNil => None,
@@ -62,19 +62,19 @@ impl EvalOptions {
         let stdlib = match t.raw_get("stdlib")? {
             LuaValue::String(s) => {
                 let s_bytes = s.as_bytes();
-                if s_bytes == &b"seal"[..] {
+                if s_bytes.eq_ignore_ascii_case(b"Seal") {
                     EvalStdlib::Seal
-                } else if s_bytes == &b"safe"[..] {
+                } else if s_bytes.eq_ignore_ascii_case(b"Safe") {
                     EvalStdlib::Safe
-                } else if s_bytes == &b"none"[..] {
+                } else if s_bytes.eq_ignore_ascii_case(b"None") {
                     EvalStdlib::None
                 } else {
-                    return wrap_err!("{} expected EvalOptions.stdlib to be \"seal\" or \"safe\" or \"none\" or nil, got an invalid string: {}", function_name, s.display())
+                    return wrap_err!("{} expected EvalOptions.stdlib to be \"Seal\" or \"Safe\" or \"None\" or nil, got an invalid string: {}", function_name, s.display())
                 }
             },
             LuaNil => EvalStdlib::Safe,
             other => {
-                return wrap_err!("{} expected EvalOptions.stdlib to be \"seal\" or \"safe\" or \"none\" or nil, got: {:?}", function_name, other);
+                return wrap_err!("{} expected EvalOptions.stdlib to be \"Seal\" or \"Safe\" or \"None\" or nil, got: {:?}", function_name, other);
             }
         };
 
@@ -90,9 +90,27 @@ impl EvalOptions {
             }
         };
 
+        let globals = match t.raw_get("globals")? {
+            Some(LuaValue::Table(t)) => {
+                // sanity check to ensure all k,v pairs have string keys
+                for pair in t.pairs::<LuaValue, LuaValue>() {
+                    let (key, _) = pair?;
+                    if !matches!(key, LuaValue::String(_)) {
+                        return wrap_err!("{}: globals environment table should only have string keys, got an {:#?} as a key", function_name, key);
+                    }
+                }
+                Some(t)
+            },
+            Some(LuaNil) | None => None,
+            Some(other) => {
+                return wrap_err!("{} expected globals to be a table with string keys or nil, got: {:?}", function_name, other);
+            }
+        };
+
         Ok(EvalOptions {
             name,
             stdlib,
+            globals
         })
     }
 }
@@ -113,7 +131,7 @@ fn get_safe_globals(luau: &Lua) -> LuaResult<LuaTable> {
     };
     t.raw_set("_VERSION", "Luau")?;
     let dummy_require_fn = luau.create_function(|_l: &Lua, _v: LuaValue| -> LuaValueResult {
-        wrap_err!("require is not allowed in \"safe\" mode! use \"seal\" stdlib to allow requires.")
+        wrap_err!("require is not allowed in \"Safe\" mode! use \"Seal\" stdlib to allow requires.")
     })?;
     t.raw_set("require", dummy_require_fn)?;
     Ok(t)
@@ -128,17 +146,32 @@ unsafe fn eval(luau: &Lua, src: Vec<u8>, eval_options: EvalOptions) -> LuaValueR
         Err(err) => Chunk::Bytecode(err.into_bytes()),
     };
 
-    let chunk = match eval_options.stdlib {
+    fn merge_globals(standard_globals: LuaTable, extra_globals: Option<LuaTable>) -> LuaResult<LuaTable> {
+        if let Some(globals) = extra_globals {
+            for pair in globals.pairs::<LuaValue, LuaValue>() {
+                let (key, value) = pair?;
+                standard_globals.set(key, value)?;
+            }
+        }
+        Ok(standard_globals)
+    }
+
+    let globals = match eval_options.stdlib {
         EvalStdlib::Safe => {
-            luau.load(code).set_name(name).set_environment(get_safe_globals(luau)?)
+            merge_globals(get_safe_globals(luau)?, eval_options.globals)?
         },
         EvalStdlib::None => {
-            luau.load(code).set_name(name).set_environment(luau.create_table()?)
+            merge_globals(luau.create_table()?, eval_options.globals)?
         },
         EvalStdlib::Seal => {
-            luau.load(code).set_name(name)
+            merge_globals(luau.globals(), eval_options.globals)?
         }
     };
+
+    let chunk = luau.load(code)
+        .set_name(name)
+        .set_environment(globals);
+
     let res = match chunk.eval::<LuaValue>() {
         Ok(value) => value,
         Err(err) => {
@@ -170,7 +203,7 @@ fn luau_eval(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResult {
         }
     };
     let eval_options = match multivalue.pop_front() {
-        Some(v) => EvalOptions::from_value(v, function_name)?,
+        Some(v) => EvalOptions::from_table(v, function_name)?,
         None => EvalOptions::default(),
     };
 
@@ -193,7 +226,7 @@ fn luau_eval_unsafe(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResult
         }
     };
     let eval_options = match multivalue.pop_front() {
-        Some(v) => EvalOptions::from_value(v, function_name)?,
+        Some(v) => EvalOptions::from_table(v, function_name)?,
         None => EvalOptions::default(),
     };
 

--- a/tests/luau/std/luau/eval.luau
+++ b/tests/luau/std/luau/eval.luau
@@ -26,7 +26,7 @@ errorsshouldntactuallyerror()
 
 local function printshouldnotbeavailableinnone()
     local src = [[print("happiness")]]
-    local res = luau.eval(src, { stdlib = "none" })
+    local res = luau.eval(src, { stdlib = "None" })
     assert(tostring(res):match("nil"), "print should be attempt to call nil")
 end
 printshouldnotbeavailableinnone()
@@ -38,7 +38,7 @@ local function seallibs()
         return str.startswith(s, "huh")
     end
     ]]
-    local f = luau.eval(src, { stdlib = "seal" }) :: (s: string) -> boolean
+    local f = luau.eval(src, { stdlib = "Seal" }) :: (s: string) -> boolean
     assert(typeof(f) == "function", "f should be function in seallibs")
     assert(f("huhmm") == true, "huhmm starts with huh")
     assert(f("hmm") == false, "hmm does not start with huh")
@@ -58,3 +58,64 @@ local function bytecodes()
     assert(res == false, "res should be false because string.meow() will error")
 end
 bytecodes()
+
+local function customenv()
+    local src = [[return meow() .. debug.info(1, "s")]]
+    local function meow()
+        return "hi i am a cat my name is nanuk"
+    end
+    local result = luau.eval(src, {
+        name = "meower",
+        stdlib = "Safe",
+        globals = {
+            meow = meow,
+        }
+    })
+    assert(result == `hi i am a cat my name is nanuk[string "meower"]`, "should be able to load custom function")
+end
+
+customenv()
+
+--- this test ensures that standard libary globals (like table.insert) are correctly
+--- merged with custom globals (first() and second())
+local function globals_are_merged()
+    local src = [[
+        local cats = {}
+        table.insert(cats, first())
+        table.insert(cats, second())
+        return cats
+    ]]
+    local result = luau.eval(src, {
+        name = "globals are merged",
+        stdlib = "safe" :: "Safe", -- intentional backwards compat test
+        globals = {
+            first = function()
+                return "this is the first cat"
+            end,
+            second = function()
+                return "this is the second cat"
+            end
+        }
+    })
+    assert(typeof(result) == "table", "merged result should be a table")
+    result = result :: { string }
+    assert(result[1] == "this is the first cat", "first element in result table should be 'this is the first cat'")
+    assert(result[2] == "this is the second cat", "second element in result table should be 'this is the second cat'")
+end
+
+globals_are_merged()
+
+local function cant_pass_wacky_globals()
+    local s, f = pcall(function()
+        local now = require("@std/time/datetime").now()
+        return luau.eval([[print("meow")]], {
+            globals = {
+                [now :: any] = now
+            }
+        })
+    end)
+    assert(s == false, "should not succeed when key in globals is DateTime userdata instead of string")
+    assert(tostring(f):match("globals environment table should only have string keys"), "error mentions passed globals table including non-string keys")
+end
+
+cant_pass_wacky_globals()


### PR DESCRIPTION
Allows luau.eval to add additional user-specified globals to the environment of `luau.eval` and `luau.eval_unsafe`, merging the table of stdlib functions with user-provided globals.

This also modifies the `stdlib` enum to use capital letters (PascalCase) to match the rest of seal stdlib enum-like string syntax. lowercase "seal" | "none" | "safe" is still allowed at runtime for backwards compat.