### PR TITLE
Allow `time.wait` to accept a Duration

### DIFF
--- a/.seal/typedefs/std/time/init.luau
+++ b/.seal/typedefs/std/time/init.luau
@@ -2,9 +2,27 @@
     A time library with `time.wait` and functions for creating `Duration` objects.
 ]=]
 export type time = {
-    --- Blocks the current VM for approximately `seconds`, accurate to millisecond-ish precision.
-    --- Implemented with Rust's `thread::sleep`.
-    wait: (seconds: number) -> true,
+    --[=[
+        Blocks the current VM for at least `duration` (which may be either a `Duration` instance
+        or a `number` in seconds).
+
+        This function should be accurate to around 1ms precision on most platforms,
+        and may be more accurate if your platform supports nanosecond precision.
+
+        ## Platform specific behavior
+
+        See the underlying Rust's `std::thread::sleep` for detailed info on platform specific behavior.
+
+        ### Linux, macOS, and Unix-like
+        - The system call may be invoked multiple times to ensure the system sleeps for `duration`
+        - A zero `duration` will not result in a `nanosleep` syscall
+
+        ### Windows
+        - Always invokes the `Sleep` system call even when a zero `Duration` is provided.
+
+        If you need a more accurate way to wait you might need to spin (while true do loop).
+    ]=]
+    wait: (duration: Duration | number) -> true,
 
     --- `DateTime` and `TimeSpan` libraries.
     datetime: typeof(require("@self/datetime")),

--- a/docs/reference/std/luau/init.md
+++ b/docs/reference/std/luau/init.md
@@ -109,6 +109,51 @@ Compiles `src` to Luau bytecode.
 
 ---
 
+### luau.bundle
+
+<h4>
+
+```luau
+function luau.bundle(path: string) -> string | error,
+```
+
+</h4>
+
+<details>
+
+<summary> See the docs </summary
+
+Bundles a Luau file or seal project at `path` using seal's bundler, inlining all
+`require()` calls recursively and hoisting `@std/*` library requires to the top.
+
+`path` can be either:
+
+- A direct path to a `.luau` file (e.g. `"./src/main.luau"`)
+- A path to a seal project directory containing a `.seal/config.luau` with an `entry_path`
+
+## Returns
+
+The bundled source code as a `string` on success, or a tostringable `error` userdata
+if bundling fails (e.g. the path doesn't exist, a require can't be resolved, or a
+circular require is detected).
+
+## Usage
+
+```luau
+local luau = require("@std/luau")
+local bundled = luau.bundle("./my_project")
+if typeof(bundled) == "error" then
+    print(`bundle failed: {bundled}`)
+else
+    -- write to file, eval, compile to bytecode, etc.
+    local result = luau.eval(bundled, { stdlib = "Seal" })
+end
+```
+
+</details>
+
+---
+
 ### luau.require_resolver
 
 <h4>

--- a/docs/reference/std/time/init.md
+++ b/docs/reference/std/time/init.md
@@ -14,13 +14,37 @@ A time library with `time.wait` and functions for creating `Duration` objects.
 <h4>
 
 ```luau
-function time.wait(seconds: number) -> true,
+function time.wait(duration: Duration | number) -> true,
 ```
 
 </h4>
 
- Blocks the current VM for approximately `seconds`, accurate to millisecond-ish precision.
- Implemented with Rust's `thread::sleep`.
+<details>
+
+<summary> See the docs </summary
+
+Blocks the current VM for at least `duration` (which may be either a `Duration` instance
+or a `number` in seconds).
+
+This function should be accurate to around 1ms precision on most platforms,
+and may be more accurate if your platform supports nanosecond precision.
+
+## Platform specific behavior
+
+See the underlying Rust's `std::thread::sleep` for detailed info on platform specific behavior.
+
+### Linux, macOS, and Unix-like
+
+- The system call may be invoked multiple times to ensure the system sleeps for `duration`
+- A zero `duration` will not result in a `nanosleep` syscall
+
+### Windows
+
+- Always invokes the `Sleep` system call even when a zero `Duration` is provided.
+
+If you need a more accurate way to wait you might need to spin (while true do loop).
+
+</details>
 
 ---
 

--- a/src/std_time/mod.rs
+++ b/src/std_time/mod.rs
@@ -9,18 +9,37 @@ pub mod timespan;
 use timespan::TimeSpan;
 use duration::TimeDuration;
 
-/// Sleeps for the given number of seconds using thread::sleep.
+/// Sleeps for the given amount of time using thread::sleep.
 ///
 /// Precision is limited to the system's sleep granularity—typically around 1ms.
-/// Values smaller than ~0.001 seconds may round down to zero and result in no actual delay.
-/// For high-precision timing, consider alternatives such as spinning or avoid using very small floats.
 ///
 /// This function is intended for simple time-based control in Luau.
-/// Avoid using for profiling or real-time control.
-fn time_wait(_luau: &Lua, seconds: LuaNumber) -> LuaValueResult {
-    let millis = (seconds * 1000.0) as u64;
-    let dur = Duration::from_millis(millis);
-    std::thread::sleep(dur);
+fn time_wait(_luau: &Lua, value: LuaValue) -> LuaValueResult {
+    let function_name = "time.wait(duration: Duration | number)";
+    let duration = match value {
+        LuaValue::Number(f) => {
+            if f.is_sign_negative() {
+                return wrap_err!("{}: cannot reverse time (got negative duration: {})", function_name, f);
+            }
+            // convert to millis so partial/decimal values get included
+            let millis = (f * 1.000) as u64;
+            Duration::from_millis(millis)
+        },
+        LuaValue::Integer(i) => {
+            Duration::from_secs(int_to_u64(i, function_name, "duration")?)
+        },
+        LuaValue::UserData(ud) if let Ok(ud) = ud.borrow::<TimeDuration>() => {
+            let signed = (*ud).inner;
+            if signed.is_negative() {
+                return wrap_err!("{}: cannot reverse time (got negative duration: {})", function_name, signed);
+            }
+            signed.unsigned_abs()
+        },
+        other => {
+            return wrap_err!("{}: expected duration to be a seal Duration or a number of seconds, got: {:?}", function_name, other);
+        }
+    };
+    std::thread::sleep(duration);
     Ok(LuaValue::Boolean(true)) // return true so while time.wait(1) loops still work
 }
 

--- a/src/std_time/mod.rs
+++ b/src/std_time/mod.rs
@@ -22,7 +22,7 @@ fn time_wait(_luau: &Lua, value: LuaValue) -> LuaValueResult {
                 return wrap_err!("{}: cannot reverse time (got negative duration: {})", function_name, f);
             }
             // convert to millis so partial/decimal values get included
-            let millis = (f * 1.000) as u64;
+            let millis = (f * 1000.0) as u64;
             Duration::from_millis(millis)
         },
         LuaValue::Integer(i) => {

--- a/tests/luau/std/time/wait.luau
+++ b/tests/luau/std/time/wait.luau
@@ -6,4 +6,13 @@ local function timewaits()
     assert(1 - (os.clock() - t0) < 0.001, "we should have 1 ms precision")
 end
 
+local function timewaitsduration()
+    local t0 = os.clock()
+    time.wait(time.milliseconds(15))
+    local since = time.seconds(os.clock() - t0)
+    assert(since.milliseconds >= 15, "should wait for at least 15 milliseconds")
+end
+
 timewaits()
+
+timewaitsduration()


### PR DESCRIPTION
Also improves documentation of how time.wait works including platform specific behavior