### PR TITLE
Configurable colors, table formatting, support NO_COLOR spec

### DIFF
--- a/.seal/typedefs/std/io/colors.luau
+++ b/.seal/typedefs/std/io/colors.luau
@@ -1,16 +1,31 @@
 --!nonstrict
 --[=[
-The `@std/io/colors` lib, because if your terminal output isn't colorized, is it even output?
+    The `@std/io/colors` lib, because if your terminal output isn't colorized, is it even output?
 
-Usage:
+    All colors functions respect the `NO_COLOR` specification, which means
+    when the `NO_COLOR` environment variable is present (not just true), they
+    return their arguments unchanged.
 
-```luau
-local colors = require("@std/io/colors")
+    Usage:
 
-print(colors.blue("my blue text"))
-```
+    ```luau
+    local colors = require("@std/io/colors")
+
+    print(colors.blue("my blue text"))
+    ```
 ]=]
 export type colors = {
+    --[=[
+        Colorizes `text` with the given truecolor `rgb` vector (`<r, g, b>`, each 0–255) and appends RESET.
+        If `text` is omitted or `""`, returns just the raw escape code (no RESET) — useful for building
+        composite strings manually.
+    ]=]
+    rgb: (rgb: vector, text: string?) -> string,
+    --- Explicitly enable or disable colors (not styling). This overrides TTY and `NO_COLOR` checks.
+    override: (enabled: boolean) -> (),
+    --- Are colors enabled?
+    enabled: () -> boolean,
+
     black: (text: string) -> string,
     red: (text: string) -> string,
     green: (text: string) -> string,

--- a/.seal/typedefs/std/io/format.luau
+++ b/.seal/typedefs/std/io/format.luau
@@ -4,8 +4,17 @@
 export type format = setmetatable<{
     --[=[
         Formats `item` in the same way as `print` or `pp`.
+
+        Pass `options` to change the behavior of the formatter.
+        If you want to change ALL print/format.pretty/etc. formatting
+        throughout seal, call `format.defaults`.
     ]=]
-    pretty: (item: unknown) -> string,
+    pretty: (item: unknown, options: FormatOptions?) -> string,
+    --[=[
+        Sets the default `FormatOptions` applied to all subsequent `print`, `format.pretty`, `format`, and `pp` calls.
+        Pass `nil` to revert to built-in defaults.
+    ]=]
+    defaults: (options: FormatOptions?) -> (),
     --[=[
         Like pretty printing but without colors.
     ]=]
@@ -23,7 +32,23 @@ export type format = setmetatable<{
     ]=]
     hexdump: (data: string | buffer) -> string,
 }, { 
-    __call: (self: any, item: unknown) -> string,
+    __call: (self: any, item: unknown, options: FormatOptions?) -> string,
 }>
+
+--- Customize how your output looks.
+export type FormatOptions = {
+    --- Table max depth.
+    max_depth: number?,
+    --- How many spaces to indent, defaults to 4
+    indent_spaces: number?,
+    --- Limit the number of elements printed in an array; defaults to 42
+    max_elements_in_array: number?,
+    --- Do you want to see `[1] = value`? Defaults to true
+    show_array_indices: boolean?,
+    --- Show `@metatable = ...` when a table has a metatable. Defaults to true
+    show_metatables: boolean?,
+    --- Show vertical guide lines at each indent level, colored by depth. Defaults to true when indent_spaces < 3
+    guidelines: boolean?,
+}
 
 return {} :: format

--- a/.seal/typedefs/std/terminal/init.luau
+++ b/.seal/typedefs/std/terminal/init.luau
@@ -356,7 +356,16 @@ export type terminal = {
         end
         ```
     ]=]
-    execute: (...TerminalAction) -> ()
+    execute: (...TerminalAction) -> (),
+    --[=[
+        Queries the terminal for its background color via the OSC 11 escape sequence.
+
+        Returns a vector of `<r, g, b>` with each channel in the 0–255 range,
+        or `nil` if the terminal doesn't respond within 150ms or doesn't support the query.
+
+        Temporarily enables raw mode if not already active.
+    ]=]
+    background: () -> vector?
 }
 
 type ClearMode =

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It can surreptitiously replace your shell and single-use Python scripts with Lua
 - *seal* projects are more scalable than shell scripts.
 - Built in terminal manipulation for TUIs.
 - Powerful multithreading.
-- <!-- Start-Precommit-Marker-1 -->1089<!-- End-Precommit-Marker-1 --> handcrafted error messages.
+- <!-- Start-Precommit-Marker-1 -->1095<!-- End-Precommit-Marker-1 --> handcrafted error messages.
 
 ## Install
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,5 +1,37 @@
 # 0.9.0
 
+## Configurable colors and formatting
+
+*seal* now respects the [NO_COLOR](https://no-color.org/) specification.
+
+### New features in std/io/format
+
+Added `format.FormatOptions` which you can pass to `format.pretty` and `format()`; pass it to `format.defaults` to override the behavior of `print` and `pp`.
+
+These options now include these new features:
+
+- print guidelines (automatically enabled when indent < 3)
+- configurable number of spaces to indent over
+- enable/disable printing metatables
+- limit the amount of array elements shown
+- enable/disable array indices (if you only care about seeing the values)
+- max table depth after which the formatter stops recursing.
+
+General formatter improvements:
+
+- Formatter now prints function names when available and not equivalent to their table key value.
+- Formatter now prints snowflakes around frozen tables.
+
+### New features in std/terminal
+
+- `terminal.background` which gets the current background color of the terminal if supported. Might not be supported on all platforms/terminals.
+
+### Changes to std/io/colors
+
+- `colors.rgb` which allows generating arbitrary terminal colors.
+- `colors.override` enables or disables colors at runtime.
+- `colors.enabled` checks if colors are enabled or disabled for whatever reason (NO_COLOR/etc.)
+
 ## Implement `_RUNTIME` and `_LUAU` specification, modify `_VERSION`
 
 I implemented [Bottersnike's specification](https://gist.github.com/Bottersnike/001470cbbb0cd63d9790a542ed5be1bf) so it's easier for portable code to branch on Luau runtimes.

--- a/docs/reference/std/io/colors.md
+++ b/docs/reference/std/io/colors.md
@@ -7,6 +7,10 @@
 
 The `@std/io/colors` lib, because if your terminal output isn't colorized, is it even output?
 
+All colors functions respect the `NO_COLOR` specification, which means
+when the `NO_COLOR` environment variable is present (not just true), they
+return their arguments unchanged.
+
 Usage:
 
 ```luau
@@ -14,6 +18,50 @@ local colors = require("@std/io/colors")
 
 print(colors.blue("my blue text"))
 ```
+
+---
+
+### colors.rgb
+
+<h4>
+
+```luau
+function colors.rgb(rgb: vector, text: string?) -> string,
+```
+
+</h4>
+
+Colorizes `text` with the given truecolor `rgb` vector (`<r, g, b>`, each 0–255) and appends RESET.
+If `text` is omitted or `""`, returns just the raw escape code (no RESET) — useful for building
+composite strings manually.
+
+---
+
+### colors.override
+
+<h4>
+
+```luau
+function colors.override(enabled: boolean) -> (),
+```
+
+</h4>
+
+ Explicitly enable or disable colors (not styling). This overrides TTY and `NO_COLOR` checks.
+
+---
+
+### colors.enabled
+
+<h4>
+
+```luau
+function colors.enabled() -> boolean,
+```
+
+</h4>
+
+ Are colors enabled?
 
 ---
 

--- a/docs/reference/std/io/format.md
+++ b/docs/reference/std/io/format.md
@@ -14,12 +14,31 @@ Format objects for pretty printing to stdout/stderr.
 <h4>
 
 ```luau
-function format.pretty(item: unknown) -> string,
+function format.pretty(item: unknown, options: FormatOptions?) -> string,
 ```
 
 </h4>
 
 Formats `item` in the same way as `print` or `pp`.
+
+Pass `options` to change the behavior of the formatter.
+If you want to change ALL print/format.pretty/etc. formatting
+throughout seal, call `format.defaults`.
+
+---
+
+### format.defaults
+
+<h4>
+
+```luau
+function format.defaults(options: FormatOptions?) -> (),
+```
+
+</h4>
+
+Sets the default `FormatOptions` applied to all subsequent `print`, `format.pretty`, `format`, and `pp` calls.
+Pass `nil` to revert to built-in defaults.
 
 ---
 
@@ -84,10 +103,114 @@ Returns a hexdump-formatted string of the provided string or buffer, similar to 
 <h4>
 
 ```luau
-function format.__call(self: any, item: unknown) -> string,
+function format.__call(self: any, item: unknown, options: FormatOptions?) -> string,
 ```
 
 </h4>
+
+---
+
+## `export type` FormatOptions
+
+<h4>
+
+```luau
+export type FormatOptions = {
+```
+
+</h4>
+
+ Customize how your output looks.
+
+---
+
+### FormatOptions.max_depth
+
+<h4>
+
+```luau
+  max_depth: number?,
+```
+
+</h4>
+
+ Table max depth.
+
+---
+
+### FormatOptions.indent_spaces
+
+<h4>
+
+```luau
+  indent_spaces: number?,
+```
+
+</h4>
+
+ How many spaces to indent, defaults to 4
+
+---
+
+### FormatOptions.max_elements_in_array
+
+<h4>
+
+```luau
+  max_elements_in_array: number?,
+```
+
+</h4>
+
+ Limit the number of elements printed in an array; defaults to 42
+
+---
+
+### FormatOptions.show_array_indices
+
+<h4>
+
+```luau
+  show_array_indices: boolean?,
+```
+
+</h4>
+
+ Do you want to see `[1] = value`? Defaults to true
+
+---
+
+### FormatOptions.show_metatables
+
+<h4>
+
+```luau
+  show_metatables: boolean?,
+```
+
+</h4>
+
+ Show `@metatable = ...` when a table has a metatable. Defaults to true
+
+---
+
+### FormatOptions.guidelines
+
+<h4>
+
+```luau
+  guidelines: boolean?,
+```
+
+</h4>
+
+ Show vertical guide lines at each indent level, colored by depth. Defaults to true when indent_spaces < 3
+
+---
+
+```luau
+} -- closes FormatOptions
+```
 
 ---
 

--- a/docs/reference/std/terminal/README.md
+++ b/docs/reference/std/terminal/README.md
@@ -623,7 +623,7 @@ This function is idempotent and safe to call multiple times.
 <h4>
 
 ```luau
-function terminal.execute(...TerminalAction) -> ()
+function terminal.execute(...TerminalAction) -> (),
 ```
 
 </h4>
@@ -681,6 +681,25 @@ end
 ```
 
 </details>
+
+---
+
+### terminal.background
+
+<h4>
+
+```luau
+function terminal.background() -> vector?
+```
+
+</h4>
+
+Queries the terminal for its background color via the OSC 11 escape sequence.
+
+Returns a vector of `<r, g, b>` with each channel in the 0–255 range,
+or `nil` if the terminal doesn't respond within 150ms or doesn't support the query.
+
+Temporarily enables raw mode if not already active.
 
 ---
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -67,7 +67,9 @@ pub fn setup_panic_hook() {
             .unwrap_or_else(|| "Unknown error running the custom panic hook, please report this to the manager (deviaze)".to_string());
 
         if let Some(location) = info.location() {
-            let payload_line = format!("{}[PANIC! IN THE SEAL INTERNALS]: {}{}{}{}", colors::BOLD_RED, colors::RESET, colors::YELLOW, payload, colors::RESET);
+            let nc = colors::are_disabled();
+            let (bold_red, yellow, red, reset) = if nc { ("", "", "", "") } else { (colors::BOLD_RED, colors::YELLOW, colors::RED, colors::RESET) };
+            let payload_line = format!("{}[PANIC! IN THE SEAL INTERNALS]: {}{}{}{}", bold_red, reset, yellow, payload, reset);
             let panic_top_line = format!("panic occurred at: [\"{}\"]:{}:{}", location.file(), location.line(), location.column());
             let rust_backtrace: Option<String> = if let Ok(var) = std::env::var("RUST_BACKTRACE") && !var.eq_ignore_ascii_case("0") {
                 Some(std::backtrace::Backtrace::capture().to_string())
@@ -76,14 +78,14 @@ pub fn setup_panic_hook() {
             };
 
             let mut stderr = std::io::stderr().lock();
-            
+
             let we_should_have_stderr_stream = crate::std_io::input::EXPECT_OUTPUT_STREAMS.stderr();
             if we_should_have_stderr_stream {
                 // we should have access to a sane stderr to print on so let's just report to it
                 let _ = writeln!(stderr, "{}\n{}", payload_line, panic_top_line);
                 let _ = writeln!(stderr,
                     "{}\nseal panicked. seal is not supposed to panic, so you've found a bug.\nPlease report it here: https://github.com/seal-runtime/seal/issues{}",
-                    colors::RED, colors::RESET
+                    red, reset
                 );
                 if let Some(ref bt) = rust_backtrace {
                     let _ = writeln!(stderr, "\nRUST BACKTRACE:\n{}", bt);
@@ -108,8 +110,10 @@ pub fn setup_panic_hook() {
 }
 
 pub fn display_error_and_exit(err: LuaError) -> ! {
+    let nc = colors::are_disabled();
+    let (bold_red, bold_yellow, reset) = if nc { ("", "", "") } else { (colors::BOLD_RED, colors::BOLD_YELLOW, colors::RESET) };
     let err = parse_traceback(err.to_string());
-    let error_message = format!("{}[ERR]{} {}", colors::BOLD_RED, colors::RESET, err);
+    let error_message = format!("{}[ERR]{} {}", bold_red, reset, err);
 
     let mut stderr = std::io::stderr().lock();
 
@@ -131,7 +135,7 @@ pub fn display_error_and_exit(err: LuaError) -> ! {
             crossterm::cursor::Show,
             crossterm::terminal::Clear(crossterm::terminal::ClearType::FromCursorDown),
         );
-        let warning_message = format!("{}[WARN]{} the program errored in terminal raw mode; switching back to cooked mode and returning control to the user.", colors::BOLD_YELLOW, colors::RESET);
+        let warning_message = format!("{}[WARN]{} the program errored in terminal raw mode; switching back to cooked mode and returning control to the user.", bold_yellow, reset);
         let _ = writeln!(stderr, "{}", warning_message);
     }
 
@@ -159,10 +163,12 @@ pub fn display_error_and_exit(err: LuaError) -> ! {
 
 #[macro_export]
 macro_rules! wrap_err {
-    ($msg:expr) => {
-        Err(LuaError::external(format!("{}{}{}", colors::RED, $msg, colors::RESET)))
-    };
-    ($msg:expr, $($arg:tt)*) => {
-        Err(LuaError::external(format!("{}{}{}", colors::RED, format!($msg, $($arg)*), colors::RESET)))
-    };
+    ($msg:expr) => {{
+        let msg = $msg.to_string();
+        Err(LuaError::external(if colors::are_disabled() { msg } else { format!("{}{}{}", colors::RED, msg, colors::RESET) }))
+    }};
+    ($msg:expr, $($arg:tt)*) => {{
+        let msg = format!($msg, $($arg)*);
+        Err(LuaError::external(if colors::are_disabled() { msg } else { format!("{}{}{}", colors::RED, msg, colors::RESET) }))
+    }};
 }

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -10,7 +10,7 @@ pub fn error(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResult {
     let message = match multivalue.pop_front() {
         Some(LuaValue::String(s)) => s.to_string_lossy(),
         Some(LuaNil) | None => String::default(),
-        Some(other) => std_io::format::pretty(luau, other)?,
+        Some(other) => std_io::format::pretty(luau, other.into_lua_multi(luau)?)?,
     };
 
     let level = match multivalue.pop_front() {
@@ -31,7 +31,7 @@ pub fn error(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResult {
 }
 
 pub fn warn(luau: &Lua, warn_value: LuaValue) -> LuaValueResult {
-    let formatted_text = std_io::format::pretty(luau, warn_value)?;
+    let formatted_text = std_io::format::pretty(luau, warn_value.into_lua_multi(luau)?)?;
     eputs!("{}[WARN]{} {}{}", colors::BOLD_YELLOW, colors::RESET, formatted_text, colors::RESET)?;
     Ok(LuaNil)
 }

--- a/src/scripts/parse_traceback.luau
+++ b/src/scripts/parse_traceback.luau
@@ -32,14 +32,18 @@ local function parse_traceback(traceback: string): string
     local is_tty = terminal.tty()
     local pretty: boolean do
         local pretty_var = env.vars.get("SEAL_PRETTY_ERRORS")
-        local seal_no_colors = env.vars.get("SEAL_NO_COLORS")
+        local seal_colors = env.vars.get("SEAL_COLORS")
+        local no_color = env.vars.get("NO_COLOR")
 
-        if pretty_var and string.lower(pretty_var) == "true" then
+        if seal_colors ~= nil and string.lower(seal_colors) == "true" then
+            -- SEAL_COLORS=true explicitly opts in, overriding NO_COLOR
             pretty = true
-        elseif seal_no_colors and string.lower(seal_no_colors) == "true" then
+        elseif no_color ~= nil or (seal_colors ~= nil and string.lower(seal_colors) == "false") then
             local format = require("@std/io/format")
             traceback = format.uncolor(traceback)
             pretty = false
+        elseif pretty_var and string.lower(pretty_var) == "true" then
+            pretty = true
         elseif pretty_var and string.lower(pretty_var) == "false" then
             pretty = false
         else
@@ -52,9 +56,13 @@ local function parse_traceback(traceback: string): string
         :gsub("%s*%[C%]: in %?", "")
         :gsub(': in function <%[.+', ": in top level")
         :gsub(cwd :: string, ".")
+    local is_runtime_error = string.match(new_traceback, "runtime error: ") ~= nil
+    local is_error_error = string.match(new_traceback, "%[C%]: in function 'error'") ~= nil
+    local might_be_rust_error = string.match(new_traceback, "stack traceback.-%.rs") ~= nil
+
     if is_tty and pretty then
         local str = require("@std/str")
-        local colors = require("@std/colors")
+        local colors = require("@std/io/colors")
 
         -- syntax highlighting stuff
         local tokenmap: { [string]: (string) -> string } = {
@@ -164,14 +172,13 @@ local function parse_traceback(traceback: string): string
 
         -- new_traceback = new_traceback:gsub("stack traceback", colors.bold.yellow("stack traceback"))
         local lines = str.splitlines(new_traceback)
-        local is_runtime_error = false
-        local is_error_error = false
+        is_runtime_error = false
+        is_error_error = false
         local first_path: string?, first_line_number: string?
 
         local passed_stack_traceback = false
         local current_frame = 0
-        --- if a chunk name ends in *.rs we might have an issue in seal
-        local might_be_rust_error = false
+        might_be_rust_error = false
 
         for index, line in lines do
             if index == 1 then
@@ -230,21 +237,23 @@ local function parse_traceback(traceback: string): string
             return nil
         end)
 
-        if might_be_rust_error then
-            table.insert(lines, `\nError appears to have come from a {colors.red("Rust")} file; this might indicate a bad error message or bug in seal.\nConsider reporting this to {colors.blue("https://github.com/seal-runtime/seal/issues")}`)
-        end
-
-        if not is_runtime_error and not is_error_error then
-            local seal_need_help = env.vars.get("SEAL_NEED_HELP")
-            if seal_need_help == nil or (seal_need_help and string.lower(seal_need_help) == "true") then
-                table.insert(lines, `\nNeed help? {colors.style.dim("(set SEAL_NEED_HELP=FALSE to hide)")}\z
-                \n  Check the docs:   {colors.blue("https://github.com/seal-runtime/seal/tree/main/docs/reference")}\z
-                \n  Join the Discord: {colors.blue("https://discord.gg/3MJ37CFNWh")}`)
-            end
-        end
-
         if succ then
             new_traceback = table.concat(lines, "\n")
+        end
+    end
+
+    local colors = require("@std/io/colors")
+
+    if might_be_rust_error then
+        new_traceback ..= `\n\nError appears to have come from a {colors.red("Rust")} file; this might indicate a bad error message or bug in seal.\nConsider reporting this to {colors.blue("https://github.com/seal-runtime/seal/issues")}`
+    end
+
+    if not is_runtime_error and not is_error_error then
+        local seal_need_help = env.vars.get("SEAL_NEED_HELP")
+        if seal_need_help == nil or (seal_need_help and string.lower(seal_need_help) == "true") then
+            new_traceback ..= `\n\nNeed help? {colors.style.dim("(set SEAL_NEED_HELP=FALSE to hide)")}\z
+            \n  Check the docs:   {colors.blue("https://github.com/seal-runtime/seal/tree/main/docs/reference")}\z
+            \n  Join the Discord: {colors.blue("https://discord.gg/3MJ37CFNWh")}`
         end
     end
 

--- a/src/std_io/colors.rs
+++ b/src/std_io/colors.rs
@@ -2,7 +2,62 @@
 
 use mluau::prelude::*;
 
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
 use crate::table_helpers::TableBuilder;
+
+// needed to let wrap_err! macro work in here
+use self as colors;
+
+struct NoColorCache {
+    value: bool,
+    last_checked: Instant,
+    runtime_override: Option<bool>,
+}
+
+static NO_COLOR_CACHE: LazyLock<Mutex<NoColorCache>> = LazyLock::new(|| {
+    Mutex::new(NoColorCache {
+        value: compute_no_color(),
+        last_checked: Instant::now(),
+        runtime_override: None,
+    })
+});
+
+fn compute_no_color() -> bool {
+    if let Ok(val) = std::env::var("SEAL_COLORS") {
+        let v = val.trim().to_ascii_lowercase();
+        if v == "true" || v == "1" || v == "yes" || v == "on" || v == "y" || v == "t" {
+            return false;
+        }
+        if v == "false" || v == "0" || v == "no" || v == "off" || v == "n" || v == "f" {
+            return true;
+        }
+    }
+    std::env::var("NO_COLOR").is_ok()
+}
+
+pub fn are_disabled() -> bool {
+    let mut cache = NO_COLOR_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(forced) = cache.runtime_override {
+        return !forced;
+    }
+    if cache.last_checked.elapsed() > Duration::from_millis(150) {
+        cache.value = compute_no_color();
+        cache.last_checked = Instant::now();
+    }
+    cache.value
+}
+
+fn colors_override(_luau: &Lua, enabled: bool) -> LuaResult<()> {
+    let mut cache = NO_COLOR_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    cache.runtime_override = Some(enabled);
+    Ok(())
+}
+
+fn colors_enabled(_luau: &Lua, _: ()) -> LuaResult<bool> {
+    Ok(!are_disabled())
+}
 
 pub const RESET: &str = "\x1b[0m";
 pub const BLACK: &str = "\x1b[30m";
@@ -56,7 +111,26 @@ pub const UNDERLINE: &str = "\x1b[4m";
 
 type LuaValueResult = LuaResult<LuaValue>;
 
+fn rgb(luau: &Lua, (rgb_vec, text): (LuaVector, Option<String>)) -> LuaValueResult {
+    let function_name = "colors.rgb(rgb: vector, text: string?)";
+    if are_disabled() {
+        return Ok(LuaValue::String(luau.create_string(text.as_deref().unwrap_or(""))?));
+    }
+    let (r, g, b) = (rgb_vec.x(), rgb_vec.y(), rgb_vec.z());
+    if !(0.0..=255.0).contains(&r) || !(0.0..=255.0).contains(&g) || !(0.0..=255.0).contains(&b) {
+        return wrap_err!("{}: r, g, b must each be in the range 0-255, got: {}, {}, {}", function_name, r, g, b);
+    }
+    let code = format!("\x1b[38;2;{};{};{}m", r as u8, g as u8, b as u8);
+    match text.as_deref() {
+        Some(t) if !t.is_empty() => Ok(LuaValue::String(luau.create_string(&(code + t + RESET))?)),
+        _ => Ok(LuaValue::String(luau.create_string(&code)?)),
+    }
+}
+
 fn colorize(luau: &Lua, text: String, color_code: &str) -> LuaValueResult {
+    if are_disabled() {
+        return Ok(LuaValue::String(luau.create_string(&text)?));
+    }
     let colored_text = color_code.to_string() + &text + RESET;
     Ok(LuaValue::String(luau.create_string(&colored_text)?))
 }
@@ -125,16 +199,21 @@ fn colorize_bold_white(luau: &Lua, text: String) -> LuaValueResult {
     colorize(luau, text, BOLD_WHITE)
 }
 
+fn stylize(luau: &Lua, text: String, style_code: &str) -> LuaValueResult {
+    let styled = style_code.to_string() + &text + RESET;
+    Ok(LuaValue::String(luau.create_string(&styled)?))
+}
+
 fn style_bold(luau: &Lua, text: String) -> LuaValueResult {
-    colorize(luau, text, BOLD)
+    stylize(luau, text, BOLD)
 }
 
 fn style_dim(luau: &Lua, text: String) -> LuaValueResult {
-    colorize(luau, text, DIM)
+    stylize(luau, text, DIM)
 }
 
 fn style_underline(luau: &Lua, text: String) -> LuaValueResult {
-    colorize(luau, text, UNDERLINE)
+    stylize(luau, text, UNDERLINE)
 }
 
 pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
@@ -211,6 +290,9 @@ pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
         .with_function("magenta", colorize_magenta)?
         .with_function("cyan", colorize_cyan)?
         .with_function("white", colorize_white)?
+        .with_function("rgb", rgb)?
+        .with_function("override", colors_override)?
+        .with_function("enabled", colors_enabled)?
         .with_value("bold", bold_colors)?
         .with_value("style", styles)?
         .with_value("codes", codes)?

--- a/src/std_io/format.rs
+++ b/src/std_io/format.rs
@@ -1,7 +1,11 @@
 use crate::prelude::*;
 use mluau::prelude::*;
 
+use std::sync::{LazyLock, RwLock};
 use regex::Regex;
+
+static DEFAULT_FORMAT_OPTIONS: LazyLock<RwLock<Option<FormatOptions>>> =
+    LazyLock::new(|| RwLock::new(None));
 
 pub fn process_debug_values(result: &mut String, value: &LuaValue, depth: usize) -> LuaResult<()> {
     let left_padding = " ".repeat(2 * depth);
@@ -94,8 +98,7 @@ pub fn simple(luau: &Lua, value: LuaValue) -> LuaValueResult {
 }
 
 pub fn strip_colors(input: &str) -> String {
-    #[allow(clippy::unwrap_used, reason = "this is a valid regex")]
-    let re_colors = Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+    let re_colors = Regex::new(r"\x1b\[[0-9;]*m").expect("this is a valid regex");
     let without_colors = re_colors.replace_all(input, "");
     without_colors.to_string()
 }
@@ -113,16 +116,99 @@ fn uncolor(luau: &Lua, value: LuaValue) -> LuaValueResult {
     ))
 }
 
-pub fn pretty(luau: &Lua, value: LuaValue) -> LuaResult<String> {
+#[derive(Clone)]
+struct FormatOptions {
+    indent_spaces: Option<u32>,
+    max_depth: Option<u32>,
+    max_elements_in_array: Option<u32>,
+    show_array_indices: Option<bool>,
+    show_metatables: Option<bool>,
+    guidelines: Option<bool>,
+}
+impl FormatOptions {
+    fn from_value(value: &LuaValue, function_name: &'static str) -> LuaResult<Option<Self>> {
+        let t = match value {
+            LuaValue::Table(t) => t,
+            LuaNil => {
+                return Ok(None);
+            },
+            other => {
+                return wrap_err!("{}: expected options to be a FormatOptions table, got something else: {:?}", function_name, other);
+            }
+        };
+
+        fn check_number(t: &LuaTable, parameter_name: &'static str, function_name: &'static str) -> LuaResult<Option<u32>> {
+            let u = match t.raw_get(parameter_name)? {
+                LuaValue::Number(f) => float_to_u32(f, function_name, parameter_name)?,
+                LuaValue::Integer(i) => int_to_u32(i, function_name, parameter_name)?,
+                LuaNil => return Ok(None),
+                other => return wrap_err!("{}: expected {} to be a number, got: {:?}", function_name, parameter_name, other),
+            };
+            Ok(Some(u))
+        }
+
+        fn check_boolean(t: &LuaTable, parameter_name: &'static str, function_name: &'static str) -> LuaResult<Option<bool>> {
+            match t.raw_get(parameter_name)? {
+                LuaValue::Boolean(b) => Ok(Some(b)),
+                LuaNil => Ok(None),
+                other => wrap_err!("{}: expected {} to be a boolean or nil, got: {:?}", function_name, parameter_name, other),
+            }
+        }
+
+        let indent_spaces = check_number(t, "indent_spaces", function_name)?;
+        let max_depth = check_number(t, "max_depth", function_name)?;
+        let max_elements_in_array = check_number(t, "max_elements_in_array", function_name)?;
+        let show_array_indices = check_boolean(t, "show_array_indices", function_name)?;
+        let show_metatables = check_boolean(t, "show_metatables", function_name)?;
+        let guidelines = check_boolean(t, "guidelines", function_name)?;
+
+        Ok(Some(Self {
+            indent_spaces,
+            max_depth,
+            max_elements_in_array,
+            show_array_indices,
+            show_metatables,
+            guidelines,
+        }))
+    }
+}
+
+fn format_defaults(_luau: &Lua, value: LuaValue) -> LuaValueResult {
+    let options = FormatOptions::from_value(&value, "format.defaults")?;
+    let mut defaults = DEFAULT_FORMAT_OPTIONS.write().expect("writer should not panic");
+    *defaults = options;
+    Ok(LuaNil)
+}
+
+pub fn pretty(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaResult<String> {
+    let function_name = "format.pretty(value: any, options: FormatOptions?)";
     let formatter = cached_formatter(luau)?;
     let format_pretty: LuaFunction = formatter.raw_get("pretty")?;
-    let result = match format_pretty.call::<LuaString>(value) {
+    let Some(value) = multivalue.pop_front() else {
+        return wrap_err!("{} got nothing to format", function_name);
+    };
+
+    let options = if let Some(options) = multivalue.pop_front() {
+        FormatOptions::from_value(&options, function_name)?
+    } else {
+        DEFAULT_FORMAT_OPTIONS.read().expect("writer should not panic").clone()
+    };
+
+    let result = if let Some(options) = options {
+        let FormatOptions { indent_spaces, max_depth, max_elements_in_array, show_array_indices, show_metatables, guidelines } = options;
+        format_pretty.call::<LuaString>((value, LuaNil, LuaNil, LuaNil, indent_spaces, max_depth, max_elements_in_array, show_array_indices, show_metatables, guidelines))
+    } else {
+        format_pretty.call::<LuaString>(value)
+    };
+
+    let formatted = match result {
         Ok(text) => text.to_string_lossy(),
         Err(err) => {
-            return wrap_err!("format: error formatting: {}", err);
+            return wrap_err!("{}: unable to format value due to err: {}", function_name, err);
         }
     };
-    Ok(result)
+
+    Ok(formatted)
 }
 
 pub fn hexdump(_luau: &Lua, value: LuaValue) -> LuaResult<String> {
@@ -138,20 +224,15 @@ pub fn hexdump(_luau: &Lua, value: LuaValue) -> LuaResult<String> {
 }
 
 pub fn __call_format(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaResult<String> {
-    let function_name = "io.format(item: unknown)";
+    let function_name = "format(item: any, options: FormatOptions?)";
     pop_self(&mut multivalue, function_name)?;
-    let value = match multivalue.pop_front() {
-        Some(value) => value,
-        None => {
-            return wrap_err!("{} expected an item to format, got nothing at all (not even nil)", function_name);
-        }
-    };
-    pretty(luau, value)
+    pretty(luau, multivalue)
 }
 
 pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
     TableBuilder::create(luau)?
         .with_function("pretty", pretty)?
+        .with_function("defaults", format_defaults)?
         .with_function("simple", simple)?
         .with_function("debug", debug)?
         .with_function("uncolor", uncolor)?

--- a/src/std_io/output.rs
+++ b/src/std_io/output.rs
@@ -58,17 +58,11 @@ pub fn simple_print_and_return(luau: &Lua, multivalue: LuaMultiValue) -> LuaMult
 }
 
 pub fn pretty_print_and_return(luau: &Lua, multivalue: LuaMultiValue) -> LuaMultiResult {
-    let formatter = format::cached_formatter(luau)?;
-    let format_pretty: LuaFunction = formatter.raw_get("pretty")?;
-    
     let mut output = String::from("");
 
     for (index, value) in multivalue.iter().enumerate() {
-        let formatted = match format_pretty.call::<LuaValue>(value) {
-            Ok(LuaValue::String(text)) => text.to_string_lossy(),
-            Ok(other) => {
-                panic!("pp: format.pretty returned a non-string, got: {:?}", other);
-            },
+        let formatted = match format::pretty(luau, value.into_lua_multi(luau)?) {
+            Ok(text) => text,
             Err(err) => {
                 return wrap_err!("pp: error printing: {}", err);
             }
@@ -80,30 +74,25 @@ pub fn pretty_print_and_return(luau: &Lua, multivalue: LuaMultiValue) -> LuaMult
             output.push_str(", ");
         }
     }
-    
+
     puts!("{}", &output)?;
 
     Ok(multivalue)
 }
 
 pub fn pretty_print(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaResult<()> {
-    let formatter = format::cached_formatter(luau)?;
-    let format_pretty: LuaFunction = formatter.raw_get("pretty")?;
-
     let mut output = String::from("");
+    let values: Vec<LuaValue> = multivalue.drain(..).collect();
 
-    while let Some(value) = multivalue.pop_front() {
-        match format_pretty.call::<LuaString>(value) {
-            Ok(text) => {
-                let text = text.to_string_lossy();
-                output += &text;
-            },
+    for (index, value) in values.iter().enumerate() {
+        match format::pretty(luau, value.into_lua_multi(luau)?) {
+            Ok(text) => output += &text,
             Err(err) => {
                 return wrap_err!("print: error printing: {}", err);
             }
         };
-        if !multivalue.is_empty() {
-            output += ", ";
+        if index + 1 < values.len() {
+            output.push_str(", ");
         }
     }
     puts!("{}", &output)?;

--- a/src/std_io/output_formatter.luau
+++ b/src/std_io/output_formatter.luau
@@ -7,8 +7,10 @@
 ]]
 
 local mlua = require("@interop/mlua")
-local colors = require("@std/colors")
+local colors = require("@std/io/colors")
+local vars = require("@std/env/vars")
 local format = require("@std/io/format")
+local terminal = require("@std/terminal")
 
 local VECTOR_FOUR_WIDE_MODE = (function()
     local s, _ = pcall(function()
@@ -184,6 +186,88 @@ local BOLD_YELLOW = colors.codes.BOLD_YELLOW
 local BOLD = colors.codes.BOLD
 local DIM = colors.codes.DIM
 
+local TERM_PROGRAM = vars.get("TERM_PROGRAM")
+
+local is_tty = terminal.tty()
+local is_truecolor = (function()
+    local colorterm = vars.get("COLORTERM")
+    return colorterm == "truecolor" or colorterm == "24bit"
+end)()
+--- vscode terminal has some output bugs with emojis and similar
+local is_vscode_terminal = TERM_PROGRAM and string.lower(TERM_PROGRAM) == "vscode"
+
+-- Each entry is a (dr, dg, db) deviation from a neutral base to give the color its hue identity.
+-- The base luminance shifts so guide lines stay readable but muted against any background.
+local GUIDE_HUE_OFFSETS = {
+    vector.create(-25, 10, 10),  -- cyan
+    vector.create( 10, -25, 10),  -- magenta
+    vector.create(-25, -10, 35),  -- blue
+    vector.create( 20, 10, -35),  -- yellow
+    vector.create(-30, 15, -15),  -- green
+    vector.create( 20, -30, -30),  -- red
+}
+
+local function compute_guide_colors(): { string }
+    if not is_truecolor then
+        return { CYAN, MAGENTA, BLUE, YELLOW, GREEN, RED }
+    end
+    local bg = terminal.background()
+    local bg_lum = if bg then (0.299 * bg.x + 0.587 * bg.y + 0.114 * bg.z) / 255 else 0.12
+    local base = math.round(110 - 50 * bg_lum)
+    local result: { string } = {}
+    for _, offset in GUIDE_HUE_OFFSETS do
+        local r = math.clamp(base + offset.x, 0, 255)
+        local g = math.clamp(base + offset.y, 0, 255)
+        local b = math.clamp(base + offset.z, 0, 255)
+        table.insert(result, colors.rgb(vector.create(r, g, b)))
+    end
+    return result
+end
+
+local GUIDE_COLORS: { string } = compute_guide_colors()
+
+local colors_enabled_state: boolean = is_tty and vars.get("NO_COLOR") == nil
+
+local function apply_color_state(enabled: boolean)
+    if enabled then
+        RESET = colors.codes.RESET
+        BOLD_WHITE = colors.codes.BOLD_WHITE
+        RED = colors.codes.RED
+        BOLD_RED = colors.codes.BOLD_RED
+        CYAN = colors.codes.CYAN
+        MAGENTA = colors.codes.MAGENTA
+        BOLD_MAGENTA = colors.codes.BOLD_MAGENTA
+        BLUE = colors.codes.BLUE
+        BOLD_BLUE = colors.codes.BOLD_BLUE
+        GREEN = colors.codes.GREEN
+        YELLOW = colors.codes.YELLOW
+        BOLD_YELLOW = colors.codes.BOLD_YELLOW
+        BOLD = colors.codes.BOLD
+        DIM = colors.codes.DIM
+        GUIDE_COLORS = compute_guide_colors()
+    else
+        RESET = ""
+        BOLD_WHITE = ""
+        RED = ""
+        BOLD_RED = ""
+        CYAN = ""
+        MAGENTA = ""
+        BOLD_MAGENTA = ""
+        BLUE = ""
+        BOLD_BLUE = ""
+        GREEN = ""
+        YELLOW = ""
+        BOLD_YELLOW = ""
+        BOLD = ""
+        DIM = ""
+        GUIDE_COLORS = { "", "", "", "", "", "" }
+    end
+end
+
+if not colors_enabled_state then
+    apply_color_state(false)
+end
+
 local LEFT_BRACKET = DIM .. "[" .. RESET
 local RIGHT_BRACKET = DIM .. "]" .. RESET
 
@@ -192,7 +276,7 @@ local RIGHT_ANGLED = BOLD .. DIM .. ">" .. RESET
 
 local ID_CATCHER_PATTERN = "[.]*0x0*([%d%w]+)"
 
-local function stringify_simple_type(value: any): string
+local function stringify_simple_type(value: any, key_function_name: string?): string
     if type(value) == "number" then
         -- mlua Numbers are BOLD_BLUE and Integers are regular BLUE
         if mlua.isint(value) then
@@ -214,10 +298,19 @@ local function stringify_simple_type(value: any): string
             else "") 
             .. RED .. RIGHT_ANGLED .. RESET
     elseif type(value) == "function" then
+        -- function ids look like 0x562311bd6640, we bold the last 5 digits for ez identification
         local function_id = string.match(tostring(value), ID_CATCHER_PATTERN)
         local last_five = string.sub(function_id, #function_id - 4, # function_id)
         local first_part = string.sub(function_id, 1, #function_id - 5)
-        return BOLD_RED .. "function" .. RESET .. LEFT_ANGLED .. RED .. "0x" ..  first_part .. colors.bold.red(last_five) .. RESET .. RED .. RIGHT_ANGLED
+        -- apparently we can get the actual function name with debug.info if it was defined in luau
+        local function_name = (debug.info :: any)(value, "n")
+        if key_function_name and key_function_name == function_name then
+            function_name = ""
+        end
+        if #function_name > 0 then
+            function_name = " " .. function_name
+        end
+        return BOLD_RED .. "function" .. function_name .. RESET .. RED .. LEFT_ANGLED .. RED .. "0x" ..  first_part .. colors.bold.red(last_five) .. RESET .. RED .. RIGHT_ANGLED
     elseif type(value) == "buffer" then
         if buffer.len(value) > 512 then
             local buffer_id = string.match(tostring(value), ID_CATCHER_PATTERN)
@@ -341,6 +434,30 @@ local function sort_table_pairs(unsorted_pairs: { TablePair }): { TablePair }
     return sorted_pairs
 end
 
+local function indents(guidelines: boolean, depth: number, indent_spaces: number): (string, string)
+    local current_indent: string
+    local element_indent: string
+    if guidelines then
+        local parts: { string } = {}
+        -- truecolor colors already encode the desired muting; DIM would double-dim them
+        local dim = if is_truecolor then "" else DIM
+        for d = 0, depth - 1 do
+            local color = GUIDE_COLORS[(d % #GUIDE_COLORS) + 1]
+            local bar = if d % 2 == 0 then "┆" else "╎"
+            table.insert(parts, dim .. color .. bar .. RESET .. string.rep(" ", indent_spaces - 1))
+        end
+        current_indent = table.concat(parts)
+        local next_color = GUIDE_COLORS[(depth % #GUIDE_COLORS) + 1]
+        local next_bar = if depth % 2 == 0 then "┆" else "╎"
+        element_indent = current_indent .. dim .. next_color .. next_bar .. RESET .. string.rep(" ", indent_spaces - 1)
+    else
+        local one_indent = string.rep(" ", indent_spaces)
+        current_indent = string.rep(one_indent, depth)
+        element_indent = current_indent .. one_indent
+    end
+    return current_indent, element_indent
+end
+
 local function process_pretty_values(
     value: any,
     --- seen_tables' keys are tables since they get uniquely hashed, value is stringified path
@@ -348,12 +465,32 @@ local function process_pretty_values(
     --- recursion depth of table we're processing
     depth: number?, 
     --- used to put table paths in seen_tables
-    current_table_path: { any }?
+    current_table_path: { any }?,
+
+    -- config parameters
+
+    --- how many spaces, defaults to 4
+    indent_spaces: number?,
+    --- how deep inside a table before we say nope
+    max_depth: number?,
+    --- how many array elements to print before putting ..., defaults to 100 when not tty or everything
+    max_elements_in_array: number?,
+    show_array_indices: boolean?,
+    show_metatables: boolean?,
+    guidelines: boolean?
 ): string
     seen_tables = seen_tables or {}
-    local depth = depth or 0
+    depth = depth or 0
+    max_depth = if not is_tty then math.huge elseif max_depth then max_depth else 6
+    max_elements_in_array = if not is_tty then math.huge elseif max_elements_in_array then max_elements_in_array else 42
+    indent_spaces = indent_spaces or 4
+    show_array_indices = if show_array_indices == nil or show_array_indices == true then true else false
+    show_metatables = if show_metatables == nil or show_metatables == true then true else false
+    guidelines = if guidelines ~= nil then guidelines else indent_spaces < 3
+
+    local current_indent, element_indent = indents(guidelines, depth, indent_spaces)
+    
     local current_table_path: { any } = current_table_path or {}
-    local current_indent = string.rep("    ", depth)
     if type(value) == "table" then
         local value = value :: { [any]: any }
         local value_meta = getmetatable(value :: any) :: { [any]: any }?
@@ -363,8 +500,34 @@ local function process_pretty_values(
         -- we don't use __tostring for this because a __tostring implementation is not necessarily for displaying
         -- a user can call tostring(value) explicitly if they want that.
         if value_meta and value_meta.__display and typeof(value_meta.__display) == "function" then
-            value_meta = value_meta :: { __display: (self: any) -> unknown }
-            local success, custom_display = pcall(value_meta.__display, value)
+            value_meta = value_meta :: {
+                -- we want to allow downstream users to be able to customize how their data structure
+                -- gets formatted based upon current level of indent and relevant formatting config
+                __display: (
+                    self: any,
+                    current_indent: string,
+                    config: {
+                        max_depth: number,
+                        indent_spaces: number,
+                        max_elements_in_array: number,
+                        show_array_indices: boolean,
+                        show_metatables: boolean,
+                    }?
+                ) -> unknown
+            }
+            local success, custom_display = pcall(
+                value_meta.__display,
+                value,
+                current_indent,
+                {
+                    max_depth = max_depth,
+                    indent_spaces = indent_spaces,
+                    max_elements_in_array = max_elements_in_array,
+                    show_array_indices = show_array_indices,
+                    show_metatables = show_metatables,
+                    guidelines = guidelines,
+                }
+            )
             if success and typeof(custom_display) == "string" then
                 return custom_display
             end
@@ -377,7 +540,16 @@ local function process_pretty_values(
             table.insert(result, s)
         end
 
-        push("{\n")
+        local is_frozen = table.isfrozen(value)
+
+        push(
+            if is_frozen and is_tty then
+                "{❄️\n"
+            elseif is_frozen then
+                "{<frozen>\n"
+            else
+                "{\n"
+        )
 
         if depth == 0 then
             seen_tables[value] = BOLD_YELLOW .. "self" .. RESET -- track top level cyclic tables
@@ -387,13 +559,11 @@ local function process_pretty_values(
         local unsorted_pairs: { TablePair } = {}
         if value_meta then
             for k, v in pairs(value) do -- use pairs to avoid unexpectedly calling __call on tables w/ metatable
-                -- LUAU FIXME: table.insert horribly broken
-                (table.insert :: any)(unsorted_pairs, { key = k, val = v }) 
+                table.insert(unsorted_pairs, { key = k, val = v }) 
             end
         else
             for k, v in value do
-                -- LUAU FIXME: table.insert horribly broken
-                (table.insert :: any)(unsorted_pairs, { key = k, val = v }) 
+                table.insert(unsorted_pairs, { key = k, val = v }) 
             end
         end
 
@@ -402,137 +572,136 @@ local function process_pretty_values(
             return "{}" -- special case empty tables
         end
 
+        local array_elements_seen = 0
         for _, pair in sorted_pairs do
             local key, val = pair.key, pair.val
-            -- result ..= current_indent .. "    "
-            push(current_indent .. "    ")
+            push(element_indent)
 
             -- stringify keys
             local key_type = type(key)
             if key_type == "number" then
-                -- left pad array keys by prepending spaces in front of [
-                -- so the = signs are aligned
-                if #value > 10 and #value < 100 then
-                    if key < 10 then
-                        -- result ..= " "
-                        push(" ")
-                    end
-                elseif #value > 100 and #value < 1000 then
-                    if key < 10 then
-                        -- result ..= "  "
-                        push("  ")
-                    elseif key < 100 then
-                        -- result ..= " "
-                        push(" ")
-                    end
-                elseif #value > 1000 then
-                    if key < 10 then
-                        push("   ")
-                    elseif key < 100 then
-                        -- result ..= "  "
-                        push("  ")
-                    elseif key < 1000 then
-                        -- result ..= " "
-                        push(" ")
-                    end
+                array_elements_seen += 1
+                if array_elements_seen > max_elements_in_array then
+                    local omitted = #sorted_pairs - max_elements_in_array
+                    push(DIM .. `... ({omitted} values omitted)` .. RESET .. "\n")
+                    break
                 end
-                push(
-                    LEFT_BRACKET ..
-                    (if mlua.isint(key) then 
-                        BLUE .. tostring(key) .. RESET
-                    else 
-                        BOLD_BLUE .. tostring(key) .. RESET
-                    ) .. 
-                    RIGHT_BRACKET
-                )
+                if show_array_indices ~= false then
+                    -- left pad array keys by prepending spaces in front of [
+                    -- so the = signs are aligned
+                    if #value > 10 and #value < 100 then
+                        if key < 10 then
+                            push(" ")
+                        end
+                    elseif #value > 100 and #value < 1000 then
+                        if key < 10 then
+                            push("  ")
+                        elseif key < 100 then
+                            push(" ")
+                        end
+                    elseif #value > 1000 then
+                        if key < 10 then
+                            push("   ")
+                        elseif key < 100 then
+                            push("  ")
+                        elseif key < 1000 then
+                            push(" ")
+                        end
+                    end
+                    push(
+                        LEFT_BRACKET ..
+                        (if mlua.isint(key) then
+                            BLUE .. tostring(key) .. RESET
+                        else
+                            BOLD_BLUE .. tostring(key) .. RESET
+                        ) ..
+                        RIGHT_BRACKET
+                    )
+                end
             elseif key_type == "string" then
                 if string.match(key, IDENTIFIER_PATTERN) then
-                    -- result ..= key
                     push(key)
                 else
-                    -- result ..= LEFT_BRACKET .. GREEN .. '"' .. key .. '"' .. RESET .. RIGHT_BRACKET
                     push(LEFT_BRACKET .. GREEN .. '"' .. key .. '"' .. RESET .. RIGHT_BRACKET)
                 end
             elseif key_type == "table" then
                 local seen_name: string? = seen_tables[key]
                 if seen_name then
-                    -- result ..= LEFT_BRACKET .. seen_name .. RIGHT_BRACKET
                     push(LEFT_BRACKET .. seen_name .. RIGHT_BRACKET)
-                elseif depth + 1 > 6 then
+                elseif depth + 1 > max_depth then
                     local tableid = string.match(tostring(key), ID_CATCHER_PATTERN)
                     push(LEFT_BRACKET .. colors.cyan(`table<0x{tableid}>`) .. RIGHT_BRACKET)
                 else
-                    -- result ..= LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. RIGHT_BRACKET
                     push(
-                        LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. RIGHT_BRACKET
+                        LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path, indent_spaces, max_depth, max_elements_in_array, show_array_indices, show_metatables, guidelines) .. RIGHT_BRACKET
                     )
                 end
             else
-                -- result ..= LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. RIGHT_BRACKET
                 push(
-                    LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path) .. RIGHT_BRACKET
+                    LEFT_BRACKET .. process_pretty_values(key, seen_tables, depth + 1, current_table_path, indent_spaces, max_depth, max_elements_in_array, show_array_indices, show_metatables, guidelines) .. RIGHT_BRACKET
                 )
             end
 
-            -- result ..= " = "
-            push(" = ")
+            if key_type ~= "number" or show_array_indices ~= false then
+                push(" = ")
+            end
 
             -- stringify values
             if type(val) == "table" then
                 local val = val :: { [any]: any }
                 local seen_name: string? = seen_tables[val]
                 if seen_name then
-                    -- result ..= seen_name
                     push(seen_name)
-                elseif depth + 1 > 6 then
+                elseif depth + 1 > max_depth then
                     if next(val) == nil then -- table is empty
-                        -- result ..= "{}"
                         push("{}")
                     else
-                        -- result ..= "{" .. colors.codes.BOLD_WHITE .. "..." .. RESET .. "}"
                         push("{" .. colors.codes.BOLD_WHITE .. "..." .. RESET .. "}")
                     end
                 else
                     -- push key to current_table_path before recursion
                     table.insert(current_table_path, key)
                     seen_tables[val] = stringify_table_path(current_table_path) -- tostring(key)
-                    -- result ..= process_pretty_values(val, seen_tables, depth + 1, current_table_path)
-                    push(process_pretty_values(val, seen_tables, depth + 1, current_table_path))
+                    push(process_pretty_values(val, seen_tables, depth + 1, current_table_path, indent_spaces, max_depth, max_elements_in_array, show_array_indices, show_metatables, guidelines))
                     -- pop key from current_table_path after recursion
                     table.remove(current_table_path, #current_table_path)
                 end
             elseif type(val) == "string" then -- don't recurse in extremely common case
                 if string.find(val, "\n") then
                     if #val < 42 then
-                        -- result ..= GREEN .. '"' .. string.gsub(val, "\n", "\\n") .. '"' .. RESET
                         push(GREEN .. '"' .. string.gsub(val, "\n", "\\n") .. '"' .. RESET)
                     else
-                        -- result ..= "(newlined string starts on next line) " ..  GREEN .. "\n" .. val .. RESET .. "\n(end newlined string)"
                         push("(newlined string starts on next line) " ..  GREEN .. "\n" .. val .. RESET .. "\n(end newlined string)")
                     end
                 else
-                    -- result ..= GREEN .. '"' .. val .. '"' .. RESET
                     push(GREEN .. '"' .. val .. '"' .. RESET)
                 end
             elseif type(val) == "number" or type(val) == "boolean" then
-                -- result ..= stringify_simple_type(val)
                 push(stringify_simple_type(val))
+            elseif type(val) == "function" and key_type == "string" then
+                -- pass table key in so we can skip displaying the function_name twice if key == debug.info(val)
+                push(stringify_simple_type(val, key))
             else
-                -- result ..= process_pretty_values(val, seen_tables, depth + 1, current_table_path)
-                push(process_pretty_values(val, seen_tables, depth + 1, current_table_path))
+                push(process_pretty_values(val, seen_tables, depth + 1, current_table_path, indent_spaces, max_depth, max_elements_in_array, show_array_indices, show_metatables, guidelines))
             end
             
-            -- result ..= DIM .. "," .. RESET .. "\n"
             push(DIM .. "," .. RESET .. "\n")
         end
-        if value_meta then
-            -- result ..= current_indent .. "    " .. RED .. "@metatable" .. RESET .. " = " .. process_pretty_values(value_meta, seen_tables, depth + 1, current_table_path) .. "\n"
+        if value_meta and show_metatables then
             push(
-                current_indent .. "    " .. RED .. "@metatable" .. RESET .. " = " .. process_pretty_values(value_meta, seen_tables, depth + 1, current_table_path) .. "\n"
+                element_indent .. RED .. "@metatable" .. RESET .. " = " .. process_pretty_values(value_meta, seen_tables, depth + 1, current_table_path, indent_spaces, max_depth, max_elements_in_array, show_array_indices, show_metatables, guidelines) .. "\n"
             )
         end
-        -- result ..= current_indent .. "}"
-        push(current_indent .. "}")
+        push(current_indent .. (
+            if is_frozen and is_tty and is_vscode_terminal then
+                "❄️ }" -- vscode rendering bug
+            elseif is_frozen and is_tty then
+                "❄️}"
+            elseif is_frozen then
+                "<frozen>}"
+            else
+                "}"
+        ))
         -- return result
         return table.concat(result, "")
     elseif type(value) == "string" and depth == 0 then -- calling print("hello world") shouldn't colorize
@@ -542,7 +711,20 @@ local function process_pretty_values(
     end
 end
 
+local function pretty(value: any, ...: any): string
+    local now_enabled = colors.enabled()
+    if now_enabled ~= colors_enabled_state then
+        colors_enabled_state = now_enabled
+        apply_color_state(now_enabled)
+        LEFT_BRACKET = DIM .. "[" .. RESET
+        RIGHT_BRACKET = DIM .. "]" .. RESET
+        LEFT_ANGLED = BOLD .. DIM .. "<" .. RESET
+        RIGHT_ANGLED = BOLD .. DIM .. ">" .. RESET
+    end
+    return process_pretty_values(value, ...)
+end
+
 return {
     simple = process_raw_values,
-    pretty = process_pretty_values,
+    pretty = pretty,
 }

--- a/src/std_terminal/mod.rs
+++ b/src/std_terminal/mod.rs
@@ -270,6 +270,79 @@ fn terminal_reset(_luau: &Lua, _value: LuaValue) -> LuaEmptyResult {
     Ok(())
 }
 
+pub fn terminal_background(_luau: &Lua, _: LuaValue) -> LuaResult<LuaValue> {
+    use std::io::{Read, Write};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let function_name = "colors.background()";
+    let was_raw = crossterm::terminal::is_raw_mode_enabled().unwrap_or(false);
+    if !was_raw && let Err(e) = crossterm::terminal::enable_raw_mode() {
+        return wrap_err!("{}: failed to enable raw mode: {}", function_name, e);
+    }
+
+    let query = b"\x1b]11;?\x1b\\";
+    if let Err(e) = std::io::stdout().write_all(query).and_then(|_| std::io::stdout().flush()) {
+        if !was_raw { let _ = crossterm::terminal::disable_raw_mode(); }
+        return wrap_err!("{}: failed to write OSC query: {}", function_name, e);
+    }
+
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let mut stdin = std::io::stdin();
+        let mut buf = [0u8; 64];
+        let mut response = String::new();
+        loop {
+            match stdin.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    response.push_str(&String::from_utf8_lossy(&buf[..n]));
+                    if response.contains('\x07') || response.contains("\x1b\\") {
+                        break;
+                    }
+                }
+            }
+        }
+        let _ = tx.send(response);
+    });
+
+    let response = rx.recv_timeout(Duration::from_millis(150)).ok();
+
+    if !was_raw {
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
+
+    let Some(response) = response else {
+        return Ok(LuaNil);
+    };
+
+    // Response format: \x1b]11;rgb:RRRR/GGGG/BBBB\x1b\\ — channels are 16-bit hex; high byte = 0-255
+    let Some(rgb_part) = response.find("rgb:").map(|i| &response[i + 4..])
+        .and_then(|s| s.split(['\x07', '\\']).next())
+    else {
+        return Ok(LuaNil);
+    };
+
+    let channels: Vec<&str> = rgb_part.splitn(3, '/').collect();
+    if channels.len() != 3 {
+        return Ok(LuaNil);
+    }
+
+    let parse_channel = |hex: &str| -> Option<f32> {
+        u16::from_str_radix(&hex[..hex.len().min(4)], 16).ok().map(|v| (v >> 8) as f32)
+    };
+
+    let (Some(r), Some(g), Some(b)) = (
+        parse_channel(channels[0]),
+        parse_channel(channels[1]),
+        parse_channel(channels[2]),
+    ) else {
+        return Ok(LuaNil);
+    };
+
+    Ok(mluau::Value::Vector(mluau::Vector::new(r, g, b)))
+}
+
 pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
     TableBuilder::create(luau)?
         .with_function("tty", terminal_tty)?
@@ -284,6 +357,7 @@ pub fn create(luau: &Lua) -> LuaResult<LuaTable> {
         .with_function("events", events::events)?
         .with_function("execute", terminal_execute)?
         .with_function("reset", terminal_reset)?
+        .with_function("background", terminal_background)?
         .with_value("capture", events::create_capture_table(luau)?)?
         .with_value("rawmode", TableBuilder::create(luau)?
             .with_function("enabled", terminal_rawmode_enabled)?

--- a/tests/luau/std/io/colors.luau
+++ b/tests/luau/std/io/colors.luau
@@ -1,1 +1,77 @@
-local _colors = require("@std/io/colors")
+local colors = require("@std/io/colors")
+local format = require("@std/io/format")
+
+local function assert_contains(s: string, substr: string, label: string)
+    if not string.find(s, substr, 1, true) then
+        error(`FAIL [{label}]: expected {format.debug(s)} to contain {format.debug(substr)}`)
+    end
+    print(colors.bold.green(`PASS [{label}]`))
+end
+
+local function assert_eq(a: any, b: any, label: string)
+    if a ~= b then
+        error(`FAIL [{label}]: {format.debug(a)} ~= {format.debug(b)}`)
+    end
+    print(colors.bold.green(`PASS [{label}]`))
+end
+
+local function assert_no_ansi(s: string, label: string)
+    local stripped = format.uncolor(s)
+    if s ~= stripped then
+        error(`FAIL [{label}]: string still contains ANSI codes: {format.debug(s)}`)
+    end
+    print(colors.bold.green(`PASS [{label}]`))
+end
+
+-- basic color functions wrap text with escape codes and RESET
+assert_contains(colors.red("hello"), "hello",       "red() preserves text")
+assert_contains(colors.red("hello"), "\27[",        "red() adds escape code")
+assert_contains(colors.blue("x"),    "\27[0m",      "blue() appends RESET")
+assert_contains(colors.green("y"),   "\27[32m",     "green() uses correct code")
+
+-- bold variants
+assert_contains(colors.bold.red("hi"),  "\27[1;31m", "bold.red() uses bold+red code")
+assert_contains(colors.bold.blue("hi"), "hi",        "bold.blue() preserves text")
+
+-- style functions always apply regardless of NO_COLOR
+assert_contains(colors.style.dim("dim text"),       "\27[2m",  "style.dim() applies DIM")
+assert_contains(colors.style.bold("bold text"),     "\27[1m",  "style.bold() applies BOLD")
+assert_contains(colors.style.underline("underline"),"\27[4m",  "style.underline() applies UNDERLINE")
+
+-- rgb: with text wraps and resets; without text returns just the code
+local rgb_with = colors.rgb(vector.create(100, 150, 200), "hello")
+assert_contains(rgb_with, "hello",   "rgb() with text preserves text")
+assert_contains(rgb_with, "\27[38;2;100;150;200m", "rgb() with text uses truecolor code")
+assert_contains(rgb_with, "\27[0m",  "rgb() with text appends RESET")
+
+local rgb_code_only = colors.rgb(vector.create(100, 150, 200))
+assert_contains(rgb_code_only, "\27[38;2;100;150;200m", "rgb() without text returns code")
+assert_eq(string.find(rgb_code_only, "\27[0m", 1, true), nil, "rgb() without text has no RESET")
+
+local rgb_empty = colors.rgb(vector.create(100, 150, 200), "")
+assert_contains(rgb_empty, "\27[38;2;", "rgb() with empty string returns code only")
+assert_eq(string.find(rgb_empty, "\27[0m", 1, true), nil, "rgb() with empty string has no RESET")
+
+-- rgb() validates range
+local ok, err = pcall(function() return colors.rgb(vector.create(300, 0, 0)) end)
+assert_eq(ok, false, "rgb() errors on out-of-range channel")
+
+-- colors.override / colors.enabled toggle
+assert_eq(colors.enabled(), true, "enabled() returns true by default")
+
+colors.override(false)
+assert_eq(colors.enabled(), false, "enabled() returns false after override(false)")
+assert_no_ansi(colors.red("hello"),  "red() strips color when disabled")
+assert_no_ansi(colors.blue("world"), "blue() strips color when disabled")
+assert_eq(colors.rgb(vector.create(0, 128, 255), "hi"), "hi", "rgb() returns plain text when disabled")
+assert_eq(colors.rgb(vector.create(0, 128, 255)), "",          "rgb() returns empty code when disabled")
+
+-- style functions are NOT affected by override(false) per NO_COLOR spec
+assert_contains(colors.style.dim("still dim"),       "\27[2m", "style.dim() ignores override(false)")
+assert_contains(colors.style.bold("still bold"),     "\27[1m", "style.bold() ignores override(false)")
+
+colors.override(true)
+assert_eq(colors.enabled(), true, "enabled() returns true after override(true)")
+assert_contains(colors.red("restored"), "\27[31m", "red() works again after override(true)")
+
+print("\nAll colors tests passed.")

--- a/tests/luau/std/io/format.luau
+++ b/tests/luau/std/io/format.luau
@@ -1,4 +1,12 @@
+local env = require("@std/env")
+local colors = require("@std/io/colors")
 local format = require("@std/io/format")
+
+local function meow() end
+print({
+    meow,
+    cats = 2,
+})
 
 local t = setmetatable({
     x = 1,
@@ -8,6 +16,44 @@ local t = setmetatable({
         return hmm .. "call"
     end
 })
+
+format.defaults({
+    indent_spaces = 2,
+})
+
+local options: format.FormatOptions = {
+    indent_spaces = 2,
+    show_metatables = false,
+}
+local formatted = format.pretty(t)
+print(formatted)
+local animals = {"cats", "dogs", "seals", "walruses", { hmm = true }}
+print(animals)
+print(format.pretty(animals, {
+    indent_spaces = 6,
+    show_array_indices = false,
+}))
+-- print(t)
+-- print(format(t, {
+
+local depth_check = {
+    {
+        {
+            hi = animals
+        }, 
+        cats = 4,
+    }
+}
+colors.override(true)
+print("setting indent_spaces = 2 enables guidelines")
+print(depth_check)
+print(env)
+print("colors disabled at runtime")
+colors.override(false)
+print({ hi = "math" })
+
+print(meow)
+
 
 local pretty = format(t)
 dp(pretty)

--- a/tests/luau/std/io/format.luau
+++ b/tests/luau/std/io/format.luau
@@ -39,9 +39,10 @@ print(format.pretty(animals, {
 local depth_check = {
     {
         {
-            hi = animals
+            hi = table.freeze(animals)
         }, 
         cats = 4,
+        meow,
     }
 }
 colors.override(true)

--- a/tests/luau/std/io/readline.luau
+++ b/tests/luau/std/io/readline.luau
@@ -49,4 +49,4 @@ local function rawlinefallback()
     assert(good and good:match("good!!"), `should be good here? got: {good}`)
 end
 
-cheese.retry(rawlinefallback, 2)
+cheese.retry(rawlinefallback, 4)


### PR DESCRIPTION
## Configurable colors and formatting

*seal* now respects the [NO_COLOR](https://no-color.org/) specification.

### New features in std/io/format

Added `format.FormatOptions` which you can pass to `format.pretty` and `format()`; pass it to `format.defaults` to override the behavior of `print` and `pp`.

These options now include these new features:

- print guidelines (automatically enabled when indent < 3)
- configurable number of spaces to indent over
- enable/disable printing metatables
- limit the amount of array elements shown
- enable/disable array indices (if you only care about seeing the values)
- max table depth after which the formatter stops recursing.

General formatter improvements:

- Formatter now prints function names when available and not equivalent to their table key value.
- Formatter now prints snowflakes around frozen tables.

### New features in std/terminal

- `terminal.background` which gets the current background color of the terminal if supported. Might not be supported on all platforms/terminals.

### Changes to std/io/colors

- `colors.rgb` which allows generating arbitrary terminal colors.
- `colors.override` enables or disables colors at runtime.
- `colors.enabled` checks if colors are enabled or disabled for whatever reason (NO_COLOR/etc.)

<img width="1009" height="1296" alt="image" src="https://github.com/user-attachments/assets/d8309248-f968-4cd5-b5c7-162754e372ce" />
