### PR TITLE
Improve formatter reliability by handling nil cases explicitly

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -3,7 +3,7 @@
   "aliases": {
     "std": "./.seal/typedefs/std/",
     "interop": "./.seal/typedefs/interop/",
-    "output_formatter": "./src/std_io/output_formatter",
+    "formatter": "./src/std_io/formatter",
     "extra": "./.seal/extra/",
     "tests": "./tests/",
     "data": "./tests/data/",

--- a/src/std_io/format.rs
+++ b/src/std_io/format.rs
@@ -65,16 +65,16 @@ fn debug(luau: &Lua, stuff: LuaMultiValue) -> LuaResult<LuaString> {
     luau.create_string(&result)
 }
 
-const OUTPUT_FORMATTER_SRC: &str = include_str!("./output_formatter.luau");
+const FORMATTER_SRC: &str = include_str!("./formatter.luau");
 
 pub fn cached_formatter(luau: &Lua) -> LuaResult<LuaTable> {
     let f = luau.named_registry_value::<Option<LuaTable>>("format.formatter")?;
     if let Some(resolve) = f {
         Ok(resolve)
     } else {
-        let chunk = Chunk::Src(OUTPUT_FORMATTER_SRC.to_owned());
-        let LuaValue::Table(formatter) = luau.load(chunk).eval()? else {
-            panic!("output_formatter.luau didnt return table??");
+        let chunk = Chunk::Src(FORMATTER_SRC.to_owned());
+        let LuaValue::Table(formatter) = luau.load(chunk).set_name("@std/io/formatter.luau").eval()? else {
+            panic!("formatter.luau didnt return table??");
         };
 
         luau.set_named_registry_value("format.formatter", &formatter)?;

--- a/src/std_io/formatter.luau
+++ b/src/std_io/formatter.luau
@@ -298,7 +298,8 @@ local function stringify_simple_type(value: any, key_function_name: string?): st
         local function_id = string.match(tostring(value), ID_CATCHER_PATTERN)
         local last_five = string.sub(function_id, #function_id - 4, # function_id)
         local first_part = string.sub(function_id, 1, #function_id - 5)
-        -- apparently we can get the actual function name with debug.info if it was defined in luau
+        -- apparently we can get the actual function name with debug.info if it was defined in luau or rust/c functions with debugnames
+        -- debug.info returns "" not nil if function has no debug info
         local function_name = (debug.info :: any)(value, "n")
         local is_seal_fn_with_signature = false
         if key_function_name and key_function_name == function_name then
@@ -340,19 +341,27 @@ local function stringify_simple_type(value: any, key_function_name: string?): st
         local thread_id = string.match(tostring(value), ID_CATCHER_PATTERN)
         return "corothread" .. LEFT_ANGLED .. "0x" .. thread_id .. RIGHT_ANGLED
     elseif type(value) == "table" then -- treat a table as a simple value
-        local table_id = string.match(tostring(value), ID_CATCHER_PATTERN)
-        local last_five = string.sub(table_id, #table_id - 4, # table_id)
-        local first_part = string.sub(table_id, 1, #table_id - 5)
-        return BOLD_WHITE .. "table" .. RESET .. LEFT_ANGLED .. "0x" .. first_part .. BOLD_WHITE .. last_five .. RESET .. RIGHT_ANGLED
+        local tostringed = tostring(value)
+        local table_id = string.match(tostringed, ID_CATCHER_PATTERN)
+        if table_id then
+            local last_five = string.sub(table_id, #table_id - 4, #table_id)
+            local first_part = string.sub(table_id, 1, #table_id - 5)
+            return BOLD_WHITE .. "table" .. RESET .. LEFT_ANGLED .. "0x" .. first_part .. BOLD_WHITE .. last_five .. RESET .. RIGHT_ANGLED
+        else
+            return tostringed
+        end
     elseif type(value) == "userdata" then
-        local userdata_id = string.match(tostring(value), ID_CATCHER_PATTERN)
+        local tostringed = tostring(value)
+        local userdata_id: string? = string.match(tostringed, ID_CATCHER_PATTERN)
         local typeof_userdata = typeof(value)
-        if userdata_id == "0" then -- mluau's json null uses address 0x0000000000000000 which gets caught as "0"
+        if userdata_id and userdata_id == "0" then -- mluau's json null uses address 0x0000000000000000 which gets caught as "0"
             return colors.bold.red("null")
         elseif typeof_userdata ~= "userdata" then -- userdatas with custom names (__type)
-            return colors.bold.magenta(tostring(value)) -- we most likely have a custom tostring implementation for it
-        else
+            return colors.bold.magenta(tostringed) -- we most likely have a custom tostring implementation for it
+        elseif userdata_id then
             return BOLD_MAGENTA .. "userdata" .. RESET .. LEFT_ANGLED .. "0x" .. userdata_id .. RIGHT_ANGLED
+        else
+            return colors.bold.magenta(tostringed)
         end
     else
         return tostring(value)
@@ -421,7 +430,16 @@ local function sort_table_pairs(unsorted_pairs: { TablePair }): { TablePair }
         end
         table.sort(string_pairs, function(a: TablePair, b: TablePair)
             local a_byte, b_byte = string.byte(a.key), string.byte(b.key)
-            return a_byte < b_byte
+            -- string.byte can return 0 values, which isn't documented in hover docs or return type
+            if a_byte and b_byte then
+                return a_byte < b_byte
+            elseif a_byte and not b_byte then
+                return false
+            elseif b_byte and not a_byte then
+                return true
+            else
+                return false
+            end
         end)
     end
 
@@ -641,7 +659,8 @@ local function process_pretty_values(
                 if seen_name then
                     push(LEFT_BRACKET .. seen_name .. RIGHT_BRACKET)
                 elseif depth + 1 > max_depth then
-                    local tableid = string.match(tostring(key), ID_CATCHER_PATTERN)
+                    local tostringed = tostring(key)
+                    local tableid = string.match(tostringed, ID_CATCHER_PATTERN) or tostringed
                     push(LEFT_BRACKET .. colors.cyan(`table<0x{tableid}>`) .. RIGHT_BRACKET)
                 else
                     push(

--- a/tests/luau/globals/require/aliases.luau
+++ b/tests/luau/globals/require/aliases.luau
@@ -32,8 +32,8 @@ end
 nonexistentalias()
 
 local function aliaswithoutslashfile()
-	local process_values = (require :: any)("@output_formatter")
-	assert(process_values.simple ~= nil, "output_formatter.simple_print should be non-nil")
+	local process_values = (require :: any)("@formatter")
+	assert(process_values.simple ~= nil, "formatter.simple_print should be non-nil")
 end
 
 aliaswithoutslashfile()

--- a/tests/luau/globals/require/resolver_tests.luau
+++ b/tests/luau/globals/require/resolver_tests.luau
@@ -159,11 +159,11 @@ local function aliases()
 	)
 
 	local opv_result = resolver.resolve(
-		"@output_formatter",
+		"@formatter",
 		bibdebugname
 	) :: any
 	assert(
-		opv_result.path == fs.path.join(fs.path.cwd(), "src", "std_io", "output_formatter.luau"),
+		opv_result.path == fs.path.join(fs.path.cwd(), "src", "std_io", "formatter.luau"),
 		"requiring aliases defined upwards (not closest .luaurc) should also resolve"
 	)
 end

--- a/tests/luau/std/io/format.luau
+++ b/tests/luau/std/io/format.luau
@@ -60,3 +60,20 @@ local pretty = format(t)
 dp(pretty)
 local debuggable = format.debug(t)
 print(debuggable)
+
+colors.override(true)
+
+local withmeta = setmetatable({ isacat = true }, {
+    __tostring = function(self)
+        return "meow"
+    end
+})
+
+local other = setmetatable({meower = 2}, {
+    __tostring = function(self)
+        return "meower2"
+    end
+})
+
+local t2 = { [withmeta] = { [other] = "hehe" } }
+print(t2)


### PR DESCRIPTION
Fixes multiple bugs caused by incorrect usage of functions returning ...T that are incorrectly not required to be nilchecked by the Luau type checker. Also fixes a bad error message when encountering runtime errors within the formatter by displaying a Rust file instead of the Luau formatter.