### PR TITLE
Switch back to rustls, allow custom SSL certs, allow toggling of system certs option

### DIFF
--- a/.seal/typedefs/std/net/http/init.luau
+++ b/.seal/typedefs/std/net/http/init.luau
@@ -1,5 +1,19 @@
 --[=[
     Send HTTP Requests.
+
+    By default, the http and websocket libaries trust only system certs.
+
+    If no system certs are found, http library functions will throw an error.
+    It should be very rare for no system certs to be found, and should only really
+    be possible on barebones Linux distros. If that happens, turn off `SEAL_SYSTEM_CERTS` 
+    to force usage of Mozilla CAs.
+
+    To provide custom SSL certs, set `SSL_CERT_FILE` to a `.pem` certificate file,
+    and to disable system certs set `SEAL_SYSTEM_CERTS=false`.
+
+    - If `SEAL_SYSTEM_CERTS=false` and an `SSL_CERT_FILE` is not provided, falls back to
+    Mozilla's public CA. 
+    - If an `SSL_CERT_FILE` is provided and `SEAL_SYSTEM_CERTS=false`, seal trusts only the `SSL_CERT_FILE`.
 ]=]
 export type http = {
     --[=[

--- a/.seal/typedefs/std/net/init.luau
+++ b/.seal/typedefs/std/net/init.luau
@@ -1,3 +1,17 @@
+--[=[
+    By default, the http and websocket libaries trust system certs, and have
+    differing behavior if zero system certs are found.
+    - The http library will throw errors due to ureq internals not allowing me
+    to write a happier fallback path, to handle this
+    - The websocket library will fall back to Mozilla CAs.
+
+    To provide custom SSL certs, set `SSL_CERT_FILE` to a `.pem` certificate file,
+    and to disable system certs set `SEAL_SYSTEM_CERTS=false`.
+
+    - If `SEAL_SYSTEM_CERTS=false` and an `SSL_CERT_FILE` is not provided, falls back to
+    Mozilla's public CA. 
+    - If an `SSL_CERT_FILE` is provided and `SEAL_SYSTEM_CERTS=false`, seal trusts only the `SSL_CERT_FILE`.
+]=]
 local net = {}
 
 net.http = require("@std/net/http")

--- a/.seal/typedefs/std/net/websocket.luau
+++ b/.seal/typedefs/std/net/websocket.luau
@@ -1,3 +1,14 @@
+--[=[
+    By default, the websocket library trusts only system certs 
+    and will fallback to Mozilla's CAs only if no certs are found.
+
+    To provide custom SSL certs, set `SSL_CERT_FILE` to a `.pem` certificate file,
+    and to disable system certs set `SEAL_SYSTEM_CERTS=false`.
+
+    - If `SEAL_SYSTEM_CERTS=false` and an `SSL_CERT_FILE` is not provided, falls back to
+    Mozilla's public CA. 
+    - If an `SSL_CERT_FILE` is provided and `SEAL_SYSTEM_CERTS=false`, seal trusts only the `SSL_CERT_FILE`.
+]=]
 export type socket = {
     --[=[
         Connect to the WebSocket at `url` as a client, returning a `Websocket` handle.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "mime-type",
  "sevenz-rust",
  "tar",
- "thiserror",
+ "thiserror 2.0.19",
  "zip",
  "zstd",
 ]
@@ -238,6 +238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -507,7 +523,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -517,17 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
-dependencies = [
- "pem-rfc7468 1.0.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -659,12 +665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,21 +701,6 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1073,6 +1058,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,23 +1352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,47 +1487,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1565,15 +1540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,7 +1578,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
+ "der",
  "pkcs8",
  "spki",
 ]
@@ -1623,7 +1589,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "spki",
 ]
 
@@ -1939,12 +1905,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2037,6 +2068,9 @@ dependencies = [
  "ring",
  "rpassword",
  "rsa",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "rustyline",
  "serde-xml-rs",
  "serde_json_lenient",
@@ -2049,6 +2083,7 @@ dependencies = [
  "ureq",
  "url",
  "urlencoding",
+ "webpki-roots 1.0.9",
  "zstd",
 ]
 
@@ -2117,7 +2152,7 @@ checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
 dependencies = [
  "log",
  "serde",
- "thiserror",
+ "thiserror 2.0.19",
  "xml",
 ]
 
@@ -2319,7 +2354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -2379,16 +2414,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
+name = "thiserror"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2397,7 +2428,18 @@ version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2501,10 +2543,13 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.5",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.19",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2583,17 +2628,17 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der 0.8.1",
  "flate2",
  "log",
- "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2654,12 +2699,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2747,6 +2786,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2839,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2821,6 +2887,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -2854,6 +2935,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2866,6 +2953,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2875,6 +2968,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2902,6 +3001,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2911,6 +3016,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2926,6 +3037,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2935,6 +3052,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,15 @@ regex = "1.11.1"
 # needed for seal setup (really useful!)
 include_dir = { version = "0.7.4" }
 # only decent non-tokio non-async simple http request lib
-ureq = { version = "3.0.11", default-features = false, features = ["json", "native-tls", "gzip"] }
+# rustls (not native-tls) so we don't depend on libssl.so at runtime; platform-verifier lets us
+# use the OS trust store from pure rust, and we layer our own custom-CA/system-cert config on top
+# (see src/std_net/tls_config.rs)
+ureq = { version = "3.0.11", default-features = false, features = ["json", "gzip", "rustls", "platform-verifier"] }
+# used to build a shared rustls root-of-trust (system certs + optional custom CA) for ureq and tungstenite
+rustls = { version = "0.23", default-features = false, features = ["std", "ring", "logging", "tls12"] }
+rustls-pki-types = "1"
+rustls-native-certs = "0.8"
+webpki-roots = "1"
 # faster than std::mpsc, needed for @std/thread
 crossbeam-channel = { version = "0.5.15" }
 # serde_json blows up when reading jsonc so we use lenient instead
@@ -80,7 +88,7 @@ libloading = "0.9.0"
 # format.hexdump and dp
 pretty-hex = "0.4.1"
 # websockets
-tungstenite = { version = "0.29.0", features = ["native-tls"] }
+tungstenite = { version = "0.29.0", features = ["rustls-tls-native-roots", "rustls-tls-webpki-roots"] }
 url = "2.5.7"
 # needed for .env support in @std/env/vars
 dotenvy = "0.15.7"

--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ It can surreptitiously swap your one-off Python scripts and shell hacks for stri
 
 **0.8.0** is adding some huge new features such as:
 
-- customizable table formatting, more colors
 - archives
-- str.encoding/convert between string encodings (utf-8 vs different flavors of utf-16)
+- customizable table formatting, more colors
+- str.encoding/convert (utf-8 <-> different flavors of utf-16)
 - const, classes, export syntax
-- set your own ssl certs or use system certs for http/websocket libs
 
 [See all updates here](UPDATE.md)
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -9,6 +9,10 @@
   basis with `ArchiveOptions` to override some defaults. Let me know if the defaults are
   too low for y'all.
 
+## HTTP Library SSL certificate configuration & system certs
+
+- seal now respects `SSL_CERT_FILE` and allows you to enable/disable `SEAL_SYSTEM_CERTS` (defaults to enabled) to trust system stores. To trust Mozilla CAs instead, set this to `false`.
+
 ## Classes, export, and const
 
 Added experimental support for Luau's experimental classes feature, and brought us to

--- a/docs/reference/std/net/http/README.md
+++ b/docs/reference/std/net/http/README.md
@@ -7,6 +7,20 @@
 
 Send HTTP Requests.
 
+By default, the http and websocket libaries trust only system certs.
+
+If no system certs are found, http library functions will throw an error.
+It should be very rare for no system certs to be found, and should only really
+be possible on barebones Linux distros. If that happens, turn off `SEAL_SYSTEM_CERTS`
+to force usage of Mozilla CAs.
+
+To provide custom SSL certs, set `SSL_CERT_FILE` to a `.pem` certificate file,
+and to disable system certs set `SEAL_SYSTEM_CERTS=false`.
+
+- If `SEAL_SYSTEM_CERTS=false` and an `SSL_CERT_FILE` is not provided, falls back to
+Mozilla's public CA.
+- If an `SSL_CERT_FILE` is provided and `SEAL_SYSTEM_CERTS=false`, seal trusts only the `SSL_CERT_FILE`.
+
 ---
 
 ### http.get

--- a/docs/reference/std/net/websocket.md
+++ b/docs/reference/std/net/websocket.md
@@ -5,6 +5,16 @@
 
 `local websocket = require("@std/net/websocket")`
 
+By default, the websocket library trusts only system certs
+and will fallback to Mozilla's CAs only if no certs are found.
+
+To provide custom SSL certs, set `SSL_CERT_FILE` to a `.pem` certificate file,
+and to disable system certs set `SEAL_SYSTEM_CERTS=false`.
+
+- If `SEAL_SYSTEM_CERTS=false` and an `SSL_CERT_FILE` is not provided, falls back to
+Mozilla's public CA.
+- If an `SSL_CERT_FILE` is provided and `SEAL_SYSTEM_CERTS=false`, seal trusts only the `SSL_CERT_FILE`.
+
 ---
 
 ### socket.connect

--- a/src/std_net/http/http_request/sender.rs
+++ b/src/std_net/http/http_request/sender.rs
@@ -22,10 +22,10 @@ macro_rules! configure_config_builder {
                 .http_status_as_error(false)
                 .tls_config(
                     ureq::tls::TlsConfig::builder()
-                        .provider(ureq::tls::TlsProvider::NativeTls)
-                        // use the OS trust store (schannel/Windows, system OpenSSL/Linux) instead of
-                        // TlsConfig's default RootCerts::WebPki, which disables platform roots entirely
-                        .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+                        .provider(ureq::tls::TlsProvider::Rustls)
+                        // combines the OS trust store and/or a custom CA bundle depending on
+                        // SEAL_SYSTEM_CERTS/SSL_CERT_FILE; see std_net::tls_config
+                        .root_certs(crate::std_net::tls_config::ureq_root_certs())
                         .build()
                 );
 

--- a/src/std_net/mod.rs
+++ b/src/std_net/mod.rs
@@ -3,6 +3,7 @@ use mluau::prelude::*;
 pub mod http;
 pub mod serve;
 pub mod websocket;
+pub mod tls_config;
 
 use crate::prelude::*;
 

--- a/src/std_net/tls_config.rs
+++ b/src/std_net/tls_config.rs
@@ -1,0 +1,162 @@
+//! Shared TLS trust configuration for @std/net's http requests (ureq) and websockets
+//! (tungstenite). Both are configured from the same env vars so behavior is consistent
+//! across both.
+//!
+//! - `SSL_CERT_FILE`: path to a PEM file containing one or more additional CA
+//!   certificates to trust (e.g. a corporate MITM proxy or self-hosted CA).
+//! - `SEAL_SYSTEM_CERTS`: whether to also trust the OS's certificate store. Defaults to
+//!   true; set to "0"/"false"/"no" to trust *only* the certs from `SSL_CERT_FILE`
+//!   (or, if that's unset too, only the bundled Mozilla root list).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use ureq::tls::{Certificate, PemItem, RootCerts};
+
+fn warn(message: &str) {
+    let mut stderr = std::io::stderr().lock();
+    let _ = writeln!(stderr, "[WARN] {}", message);
+}
+
+struct TlsSettings {
+    ca_cert_path: Option<PathBuf>,
+    use_system_certs: bool,
+}
+
+impl TlsSettings {
+    fn from_env() -> Self {
+        let ca_cert_path = std::env::var_os("SSL_CERT_FILE").map(PathBuf::from);
+        let use_system_certs = match std::env::var("SEAL_SYSTEM_CERTS") {
+            Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no"),
+            Err(_) => true,
+        };
+        Self { ca_cert_path, use_system_certs }
+    }
+}
+
+fn settings() -> &'static TlsSettings {
+    static SETTINGS: OnceLock<TlsSettings> = OnceLock::new();
+    SETTINGS.get_or_init(TlsSettings::from_env)
+}
+
+/// Loads and parses the user-provided CA cert bundle (if any).
+fn custom_ca_certs() -> &'static [Certificate<'static>] {
+    static CUSTOM_CERTS: OnceLock<Vec<Certificate<'static>>> = OnceLock::new();
+    CUSTOM_CERTS.get_or_init(|| {
+        let Some(path) = &settings().ca_cert_path else {
+            return Vec::new();
+        };
+
+        let bytes = match std::fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                warn(&format!("SSL_CERT_FILE={} could not be read: {}", path.display(), err));
+                return Vec::new();
+            }
+        };
+
+        let certs: Vec<Certificate<'static>> = ureq::tls::parse_pem(&bytes)
+            .filter_map(|item| match item {
+                Ok(PemItem::Certificate(cert)) => Some(cert),
+                Ok(_) => None,
+                Err(err) => {
+                    warn(&format!("error parsing SSL_CERT_FILE={}: {}", path.display(), err));
+                    None
+                }
+            })
+            .collect();
+
+        if certs.is_empty() {
+            warn(&format!("SSL_CERT_FILE={} contains no PEM-encoded certificates", path.display()));
+        }
+
+        certs
+    })
+}
+
+fn native_certs_as_ureq_certs() -> Vec<Certificate<'static>> {
+    let result = rustls_native_certs::load_native_certs();
+    for err in &result.errors {
+        warn(&format!("error loading a system root certificate: {}", err));
+    }
+    result
+        .certs
+        .into_iter()
+        .map(|der| Certificate::from_der(der.as_ref()).to_owned())
+        .collect()
+}
+
+/// The `ureq::tls::RootCerts` to use, combining `SSL_CERT_FILE` and
+/// `SEAL_SYSTEM_CERTS` as configured.
+pub fn ureq_root_certs() -> RootCerts {
+    static ROOT_CERTS: OnceLock<RootCerts> = OnceLock::new();
+    ROOT_CERTS
+        .get_or_init(|| {
+            let custom = custom_ca_certs();
+            let use_system = settings().use_system_certs;
+
+            match (custom.is_empty(), use_system) {
+                (true, true) => RootCerts::PlatformVerifier,
+                (true, false) => RootCerts::WebPki,
+                (false, _) => {
+                    let mut certs = custom.to_vec();
+                    if use_system {
+                        certs.extend(native_certs_as_ureq_certs());
+                    }
+                    RootCerts::new_with_certs(&certs)
+                }
+            }
+        })
+        .clone()
+}
+
+/// The rustls `ClientConfig` websockets (tungstenite) should use, sharing the same
+/// trust settings as `ureq_root_certs`.
+pub fn rustls_client_config() -> Arc<rustls::ClientConfig> {
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    CONFIG
+        .get_or_init(|| {
+            let mut store = rustls::RootCertStore::empty();
+            let use_system = settings().use_system_certs;
+            let custom = custom_ca_certs();
+
+            // Mozilla's bundled list is only a fallback for when we have nothing else to trust:
+            // either the system store couldn't be read, or the user disabled system certs and
+            // didn't provide their own CA either. If the user explicitly disabled system certs
+            // and provided SSL_CERT_FILE, we should trust *only* that (matching ureq_root_certs),
+            // not silently widen trust back out to the public CA list.
+            if use_system {
+                let result = rustls_native_certs::load_native_certs();
+                for err in &result.errors {
+                    warn(&format!("error loading a system root certificate: {}", err));
+                }
+                let (added, _ignored) = store.add_parsable_certificates(result.certs);
+                if added == 0 && custom.is_empty() {
+                    store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+                }
+            } else if custom.is_empty() {
+                store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            }
+
+            for cert in custom {
+                let der = rustls_pki_types::CertificateDer::from(cert.der().to_vec());
+                if let Err(err) = store.add(der) {
+                    warn(&format!("unable to trust a certificate from SSL_CERT_FILE: {}", err));
+                }
+            }
+
+            let provider = rustls::crypto::CryptoProvider::get_default()
+                .cloned()
+                .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+
+            let config = rustls::ClientConfig::builder_with_provider(provider)
+                .with_safe_default_protocol_versions()
+                .expect("rustls default protocol versions are always valid")
+                .with_root_certificates(store)
+                .with_no_client_auth();
+
+            Arc::new(config)
+        })
+        .clone()
+}

--- a/src/std_net/websocket.rs
+++ b/src/std_net/websocket.rs
@@ -4,7 +4,15 @@ use mluau::prelude::*;
 use url::Url;
 
 use std::net::TcpStream;
-use tungstenite::{Message, protocol::{CloseFrame, frame::coding::CloseCode}, stream::MaybeTlsStream};
+use tungstenite::{
+    Message,
+    Connector,
+    client::IntoClientRequest,
+    protocol::{CloseFrame, frame::coding::CloseCode},
+    stream::MaybeTlsStream,
+};
+
+use super::tls_config;
 
 struct WebsocketMessage {
     inner: Message,
@@ -293,7 +301,7 @@ fn websocket_connect(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResul
         }
     };
 
-    let (websocket, _response) = match tungstenite::connect(url.as_str()) {
+    let (websocket, _response) = match connect_with_shared_tls_config(&url) {
         Ok(pair) => pair,
         Err(err) => {
             return wrap_err!("{}: unable to connect to websocket at '{}' due to err: {}", function_name, &url, err);
@@ -301,6 +309,31 @@ fn websocket_connect(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResul
     };
 
     WebsocketWrapper::new(websocket).get_userdata(luau)
+}
+
+/// Like `tungstenite::connect`, but always passes an explicit `rustls` connector built from
+/// `std_net::tls_config` so websockets respect `SSL_CERT_FILE`/`SEAL_SYSTEM_CERTS` the same
+/// way `@std/net/http` requests do (tungstenite's default connector has no way to plug in a
+/// custom CA bundle).
+fn connect_with_shared_tls_config(
+    url: &Url
+) -> Result<(TungsteniteWebSocket, tungstenite::handshake::client::Response), tungstenite::Error> {
+    let request = url.as_str().into_client_request()?;
+
+    let is_tls = url.scheme() == "wss";
+    let host = url.host_str().ok_or(tungstenite::Error::Url(tungstenite::error::UrlError::NoHostName))?;
+    let port = url.port_or_known_default().unwrap_or(if is_tls { 443 } else { 80 });
+
+    let stream = TcpStream::connect((host, port))?;
+    stream.set_nodelay(true)?;
+
+    let connector = Connector::Rustls(tls_config::rustls_client_config());
+
+    match tungstenite::client_tls_with_config(request, stream, None, Some(connector)) {
+        Ok(pair) => Ok(pair),
+        Err(tungstenite::HandshakeError::Failure(err)) => Err(err),
+        Err(tungstenite::HandshakeError::Interrupted(_)) => unreachable!("blocking handshake should never be interrupted"),
+    }
 }
 
 // use std::net::TcpListener;


### PR DESCRIPTION
Drops libssl.so, allows configuration via environment variable, will fallbacks to mozilla cas if system certs not found but not when explicit ssl cert pem file provided

Closes #252 
Closes #248