### PR TITLE
Increase process SpawnOptions stdout and stderr capacity, accept FileSize

### DIFF
--- a/.seal/typedefs/globals.d.luau
+++ b/.seal/typedefs/globals.d.luau
@@ -137,7 +137,7 @@ type ArchiveEntry =
     This exists so you don't have to allocate an entire ArchiveEntry if you're
     just looping over all entries.
 ]=]
-export type ArchiveEntryInfo = {
+type ArchiveEntryInfo = {
     type: "File" | "Directory" | "Symlink",
     path: string,
     --- Only present when `type == "Symlink"`.
@@ -186,6 +186,8 @@ type ArchiveOptions = {
     To see what's in the archive, try printing it or calling `:paths()` or `:info(path)` on specific paths
     or indices.
 
+    To get the length of an archive, just use `#archive`.
+
     Please don't try and assume that all paths are unique because most archive types can have many entries
     with the same path (unlike a real filesystem). Attackers have been known to exploit that before.
 ]=]
@@ -198,7 +200,9 @@ declare extern type Archive with
         instead of paths unless you know all paths are unique.
     ]=]
     function get(self, path_or_index: string | number): ArchiveEntry?
-    --- Gets an entry's metadata (path, type, unix mode, mtime) without allocating the entire file's contents.
+    --[=[
+        Gets an entry's metadata (path, type, unix mode, mtime) without allocating the entire file's contents.
+    ]=]
     function info(self, path_or_index: string | number): ArchiveEntryInfo?
     --[=[
         Adds a single `ArchiveEntry` table to an existing archive in place with similar semantics to `table.insert`.
@@ -211,15 +215,17 @@ declare extern type Archive with
     --[=[
         Removes the `ArchiveEntry` element by index, shuffling all remaining entries to the front.
 
-        This function only takes an index because an archive can contain multiple identical paths,
-        use `:paths()` to get indices to remove.
+        This function only takes an index because an archive can contain multiple identical paths
+        and removal by path would therefore be a footgun.
+
+        Use `:paths()` to get indices to remove.
     ]=]
     function remove(self, index: number)
     --[=[
         Compress the archive into a buffer of the requested archive or single file format.
 
         You can just save this via `fs.readfile`. You could also use any archive library's
-        writefile function to write this directly to disk without needing to create an additional buffer.
+        writefile function to write this directly to disk without needing to create an additional buffer.`
     ]=]
     function serialize(self, format: ArchiveFormat, options: ArchiveOptions?): buffer
 

--- a/.seal/typedefs/std/process.luau
+++ b/.seal/typedefs/std/process.luau
@@ -103,6 +103,10 @@ export type process = {
     2. Running another program in the background while your program does work.
     3. Launching multiple instances of the same program in parallel.
 
+    Note that stdout and stderr buffer capacity are capped to 200 and 100 KB
+    by default respectively; see `SpawnOptions.stream`'s options to increase or
+    lower this limit.
+
     ## Usage
 
     Listen to the output of a long-running process:
@@ -296,7 +300,7 @@ export type SpawnOptions = {
         To prevent memory leaks (if you spawn a child process and never read from stdout or stderr), each stream's inner buffer capacity is capped,
         and adjustable by setting `stdout_capacity` and `stderr_capacity`, respectively.
 
-        By default, `stdout` streams are capped to 2048 bytes and `stderr` streams to 1028.
+        By default, `stdout` streams are capped to 200 KB and `stderr` streams to 100 KB.
 
         When more bytes are read from the stream than can fit in the buffer, old bytes are drained (and lost!) so the buffer
         can remain the same size (preventing memory leaks).
@@ -311,10 +315,10 @@ export type SpawnOptions = {
         By default, seal truncates bytes from the front of inner, causing old data to be lost first. Set `truncate == "back"` to override this behavior (and preserve old data at the expense of incoming data)
     ]=]
     stream: {
-        --- inner buffer capacity of `ChildProcess.stdout`, default 2048
-        stdout_capacity: number?,
-        --- inner buffer capacity of `ChildProcess.stderr`, default 1024
-        stderr_capacity: number?,
+        --- inner buffer capacity of `ChildProcess.stdout`, default 200 KB
+        stdout_capacity: number | FileSize?,
+        --- inner buffer capacity of `ChildProcess.stderr`, default 100 KB
+        stderr_capacity: number | FileSize?,
         --- what side of stdout should be truncated when full? defaults to "Front"
         stdout_truncate: ("Front" | "Back")?,
         --- what side of stderr should be truncated when full? defaults to "Front"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It can surreptitiously swap your one-off Python scripts and shell hacks for stri
 - Powerful multithreading.
 - Best pretty printer in the business for dealing with nested data.
 - All the standard compression and archive support you want but with safety and saner defaults.
-- <!-- Start-Precommit-Marker-1 -->1227<!-- End-Precommit-Marker-1 --> handcrafted error messages.
+- <!-- Start-Precommit-Marker-1 -->1229<!-- End-Precommit-Marker-1 --> handcrafted error messages.
 
 ## Big updates
 

--- a/docs/reference/std/process.md
+++ b/docs/reference/std/process.md
@@ -157,6 +157,10 @@ There are three primary usecases for `process.spawn`:
 2. Running another program in the background while your program does work.
 3. Launching multiple instances of the same program in parallel.
 
+Note that stdout and stderr buffer capacity are capped to 200 and 100 KB
+by default respectively; see `SpawnOptions.stream`'s options to increase or
+lower this limit.
+
 ## Usage
 
 Listen to the output of a long-running process:
@@ -762,7 +766,7 @@ specifically requested otherwise.
 To prevent memory leaks (if you spawn a child process and never read from stdout or stderr), each stream's inner buffer capacity is capped,
 and adjustable by setting `stdout_capacity` and `stderr_capacity`, respectively.
 
-By default, `stdout` streams are capped to 2048 bytes and `stderr` streams to 1028.
+By default, `stdout` streams are capped to 200 KB and `stderr` streams to 100 KB.
 
 When more bytes are read from the stream than can fit in the buffer, old bytes are drained (and lost!) so the buffer
 can remain the same size (preventing memory leaks).
@@ -785,12 +789,12 @@ By default, seal truncates bytes from the front of inner, causing old data to be
 <h4>
 
 ```luau
-    stdout_capacity: number?,
+    stdout_capacity: number | FileSize?,
 ```
 
 </h4>
 
- inner buffer capacity of `ChildProcess.stdout`, default 2048
+ inner buffer capacity of `ChildProcess.stdout`, default 200 KB
 
 ---
 
@@ -799,12 +803,12 @@ By default, seal truncates bytes from the front of inner, causing old data to be
 <h4>
 
 ```luau
-    stderr_capacity: number?,
+    stderr_capacity: number | FileSize?,
 ```
 
 </h4>
 
- inner buffer capacity of `ChildProcess.stderr`, default 1024
+ inner buffer capacity of `ChildProcess.stderr`, default 100 KB
 
 ---
 

--- a/src/scripts/documentation/components.luau
+++ b/src/scripts/documentation/components.luau
@@ -30,7 +30,7 @@ export class CodeblockComponent
         return "```luau\n" .. self.text .. "\n```"
     end
     function __tostring(self)
-        return enclose_component("Code","\n" .. self.text, vector.create(144, 144, 244))
+        return enclose_component("Code", "\n" .. self.text, vector.create(144, 144, 244))
     end
 end
 export class ListItem

--- a/src/std_process/options.rs
+++ b/src/std_process/options.rs
@@ -1,10 +1,17 @@
 use std::path::{Path, PathBuf};
 use std::collections::HashMap as Map;
 
-use crate::std_env::get_current_shell;
-use crate::std_io::format::hexdump;
-use crate::{prelude::*, std_process::stream::TruncateSide};
+use crate::prelude::*;
 use mluau::prelude::*;
+
+use crate::std_io::format::hexdump;
+use crate::std_env::get_current_shell;
+use crate::std_fs::file_size::{FileSize, KILOBYTE};
+
+use super::stream::TruncateSide;
+
+const DEFAULT_STDOUT_CAPACITY: usize = 200 * KILOBYTE as usize;
+const DEFAULT_STDERR_CAPACITY: usize = 100 * KILOBYTE as usize;
 
 #[derive(Debug)]
 pub enum Shell {
@@ -344,7 +351,15 @@ impl SpawnOptions {
                 match stream_table.raw_get("stdout_capacity")? {
                     LuaValue::Number(f) => float_to_usize(f, "SpawnOptions.capacity.stdout", "stdout")?,
                     LuaValue::Integer(i) => int_to_usize(i, "SpawnOptions.capacity.stdout", "stdout")?,
-                    LuaNil => 2048_usize,
+                    LuaValue::UserData(ud) => {
+                        match FileSize::borrowed(ud) {
+                            Ok(size) => size.as_bytes() as usize,
+                            Err(typ) => {
+                                return wrap_err!("expected stdout_capacity to be a number or FileSize, got userdata of type: {}", typ);
+                            }
+                        }
+                    },
+                    LuaNil => DEFAULT_STDOUT_CAPACITY,
                     other => {
                         return wrap_err!("SpawnOptions.stream.stdout expected to be number or nil, got: {:?}", other);
                     }
@@ -352,7 +367,15 @@ impl SpawnOptions {
                 match stream_table.raw_get("stderr_capacity")? {
                     LuaValue::Number(f) => float_to_usize(f, "SpawnOptions.capacity.stderr", "stderr")?,
                     LuaValue::Integer(i) => int_to_usize(i, "SpawnOptions.capacity.stderr", "stderr")?,
-                    LuaNil => 1024_usize,
+                    LuaValue::UserData(ud) => {
+                        match FileSize::borrowed(ud) {
+                            Ok(size) => size.as_bytes() as usize,
+                            Err(typ) => {
+                                return wrap_err!("expected stderr_capacity to be a number or FileSize, got userdata of type: {}", typ);
+                            }
+                        }
+                    },
+                    LuaNil => DEFAULT_STDERR_CAPACITY,
                     other => {
                         return wrap_err!("SpawnOptions.stream.stdout expected to be number or nil, got: {:?}", other);
                     }
@@ -360,7 +383,7 @@ impl SpawnOptions {
                 TruncateSide::from_value(stream_table.raw_get("stdout_truncate")?, "stdout_truncate")?,
                 TruncateSide::from_value(stream_table.raw_get("stderr_truncate")?, "stderr_truncate")?,
             ),
-            LuaNil => (2048_usize, 1024_usize, TruncateSide::Front, TruncateSide::Front),
+            LuaNil => (DEFAULT_STDOUT_CAPACITY, DEFAULT_STDERR_CAPACITY, TruncateSide::Front, TruncateSide::Front),
             other => {
                 return wrap_err!("SpawnOptions.capacity expected to be a table or nil, got: {:?}", other);
             }
@@ -385,6 +408,7 @@ impl SpawnOptions {
             stderr_truncate
         ) = Self::extract_stream_fields(spawn_options.raw_get("stream")?)?;
 
+        // TODO: implement detached/daemon processes
         // let detached = match spawn_options.raw_get("detached")? {
         //     LuaValue::Boolean(b) => b,
         //     LuaNil => false,

--- a/tests/luau/std/process/spawn/capacities.luau
+++ b/tests/luau/std/process/spawn/capacities.luau
@@ -1,11 +1,12 @@
 local fs = require("@std/fs")
 local env = require("@std/env")
+local filesize = require("@std/fs/filesize")
 local process = require("@std/process")
 local time = require("@std/time")
 local str = require("@std/str")
 local cheese = require("@tests/cheese")
 
-local function spawn_poem(stdout_capacity: number, stderr_capacity: number, stdout_truncate: "Front" | "Back"): (process.PipedChild, string)
+local function spawn_poem(stdout_capacity: FileSize, stderr_capacity: number, stdout_truncate: "Front" | "Back"): (process.PipedChild, string)
     local src = [[
     local fs = require("@std/fs")
     local time = require("@std/time")
@@ -47,7 +48,7 @@ local function spawn_poem(stdout_capacity: number, stderr_capacity: number, stdo
 end
 
 local function restrictedcapacity()
-    local child, poem_path = spawn_poem(52, 42, "Front")
+    local child, poem_path = spawn_poem(filesize.bytes(52), 42, "Front")
     assert(child.stdout:capacity() == 52, "stdout capacity should be 52")
     assert(child.stderr:capacity() == 42, "stderr capacity should be 42")
     time.wait(1)
@@ -60,7 +61,7 @@ end
 restrictedcapacity()
 
 local function truncatebackactuallytruncatesback()
-    local child, poem_path = spawn_poem(62, 0, "Back")
+    local child, poem_path = spawn_poem(filesize.bytes(62), 0, "Back")
     time.wait(0.6)
     local current_size = child.stdout:len()
     assert(current_size == 62, `inner should be fully full by now, got: {current_size}`)


### PR DESCRIPTION
increases capacity to 200 and 100 KB respectively and adds support for passing in FileSizes there