### PR TITLE
fix logic errors in archive entry.read

### DIFF
--- a/.seal/typedefs/std/archive/entry.luau
+++ b/.seal/typedefs/std/archive/entry.luau
@@ -29,11 +29,22 @@ export type entry = {
         Create an `ArchiveEntry` from existing files/directories on disk. Preserves unix permissions
         and modified time if present. Returns a single ArchiveEntry when `path` points to a file,
         or `{ ArchiveEntry }` if path points to a directory. You can pass the return of this
-        directly to `Archive:append`.
+        directly to `Archive:append`. Not able to create symlinks at this moment.
+
+        By default, archive paths for files read via this function will default to just the child/basename/filename
+        path component (`"./project/cache/important.json"` becomes a File with archive path `"important.json"`). 
         
-        Not able to create symlinks right now.
+        To preserve directory nesting, pass a second argument `as_archive_path`.
+
+        If `as_archive_path` is specified, 
+        - files will use it as an **explicit path** (`as_archive_path: "cache/important.json"`),
+        - directories will have each of their **children's names joined** to it 
+        (`as_archive_path: "cache" -> `"cache/important.json")
+
+        If `as_archive_path` is a number, **keeps the last child components** of the path instead of only the filename.
+        (`entry.read("./src/main.luau", 2)` gives File with archive path `src/main.luau`).
     ]=]
-    read: (path: string, as: string?) -> ArchiveEntry | { ArchiveEntry },
+    read: (path: string, as_archive_path: (string | number)?) -> ArchiveEntry | { ArchiveEntry },
 }
 
 return {} :: entry

--- a/docs/reference/std/archive/entry.md
+++ b/docs/reference/std/archive/entry.md
@@ -82,17 +82,35 @@ Call methods on this to set unix_mode and modified time.
 <h4>
 
 ```luau
-function entry.read(path: string, as: string?) -> ArchiveEntry | { ArchiveEntry },
+function entry.read(path: string, as_archive_path: (string | number)?) -> ArchiveEntry | { ArchiveEntry },
 ```
 
 </h4>
 
+<details>
+
+<summary> See the docs </summary
+
 Create an `ArchiveEntry` from existing files/directories on disk. Preserves unix permissions
 and modified time if present. Returns a single ArchiveEntry when `path` points to a file,
 or `{ ArchiveEntry }` if path points to a directory. You can pass the return of this
-directly to `Archive:append`.
+directly to `Archive:append`. Not able to create symlinks at this moment.
 
-Not able to create symlinks right now.
+By default, archive paths for files read via this function will default to just the child/basename/filename
+path component (`"./project/cache/important.json"` becomes a File with archive path `"important.json"`).
+
+To preserve directory nesting, pass a second argument `as_archive_path`.
+
+If `as_archive_path` is specified,
+
+- files will use it as an **explicit path** (`as_archive_path: "cache/important.json"`),
+- directories will have each of their **children's names joined** to it
+(`as_archive_path: "cache" ->`"cache/important.json")
+
+If `as_archive_path` is a number, **keeps the last child components** of the path instead of only the filename.
+(`entry.read("./src/main.luau", 2)` gives File with archive path `src/main.luau`).
+
+</details>
 
 ---
 

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -21,7 +21,7 @@ pub const STD_ARCHIVE_DEB_READFILE: &std::ffi::CStr = c"archive.deb.readfile(pat
 pub const STD_ARCHIVE_DEB_WRITEFILE: &std::ffi::CStr = c"archive.deb.writefile(path: string, archive: Archive, options: ArchiveOptions?)";
 
 // archive.entry
-pub const STD_ARCHIVE_ENTRY_READ: &std::ffi::CStr = c"archive.entry.read(path: string, as: string?) -> ArchiveEntry | { [number]: ArchiveEntry }";
+pub const STD_ARCHIVE_ENTRY_READ: &std::ffi::CStr = c"archive.entry.read(path: string, as_archive_path: string | number?) -> ArchiveEntry | { [number]: ArchiveEntry }";
 
 // archive.entry.create
 pub const STD_ARCHIVE_ENTRY_CREATE_DIRECTORY: &std::ffi::CStr = c"archive.entry.create.directory(path: string) -> ArchiveEntryDirectory";

--- a/src/std_archive/entry.rs
+++ b/src/std_archive/entry.rs
@@ -11,6 +11,11 @@ use crate::std_fs::file_size::FileSize;
 use crate::std_io::colors;
 use crate::std_time::datetime::DateTime;
 
+enum ArchiveOutputPath {
+    As(PathBuf),
+    KeepChildren(usize),
+}
+
 #[derive(PartialEq)]
 pub(super) enum EntryType {
     File,
@@ -166,17 +171,13 @@ impl WrappedArchiveEntry {
         Ok(self)
     }
 
-    fn from_file_on_disk<DiskPath: AsRef<Path>, OutPath: AsRef<Path>>(
-        path: DiskPath,
-        keep_children: usize,
-        out_path: &Option<OutPath>
-    ) -> Result<Self, std::io::Error> {
-        let contents = std::fs::read(&path)?;
+    /// Reads a single file at `disk_path` into an entry whose archive path is exactly `archive_path`
+    fn from_file_on_disk(disk_path: &Path, archive_path: &Path) -> Result<Self, std::io::Error> {
+        let contents = std::fs::read(disk_path)?;
+        Self::file(archive_path, contents).with_metadata_from_disk(disk_path)
+    }
 
-        if let Some(out_path) = out_path {
-            return Self::file(out_path, contents).with_metadata_from_disk(&path);
-        }
-
+    fn trim_path_components(path: &Path, keep_children: usize) -> PathBuf {
         // When we make archive entries from file we need to ensure that we don't save
         // the entire absolute path of the file as the 'path' because that creates archive
         // with absolute paths (which even we reject by default)
@@ -185,7 +186,6 @@ impl WrappedArchiveEntry {
         // get the last n components of the path (usually 1 unless nested dirs)
         // and basically 'collect' (fold) them into a PathBuf that we alloc above
         let components = &mut path
-            .as_ref()
             .components()
             .rev()
             .take(keep_children)
@@ -197,8 +197,8 @@ impl WrappedArchiveEntry {
                     std::ops::ControlFlow::Break(acc)
                 }
             });
-        
-        let archive_path = match components {
+
+        match components {
             std::ops::ControlFlow::Continue(b) => {
                 // components are backwards so we have to reverse them again
                 // unfortunately can't do this easily without allocing another PathBuf
@@ -206,46 +206,45 @@ impl WrappedArchiveEntry {
             },
             std::ops::ControlFlow::Break(_) => {
                 std::path::PathBuf::from(path
-                    .as_ref()
                     .file_name()
                     .unwrap_or(std::ffi::OsStr::new("<path not found>"))
                     .to_owned()
                 )
             }
-        };
-
-        Self::file(&archive_path, contents).with_metadata_from_disk(&path)
+        }
     }
 
-    fn from_directory_on_disk<DiskPath: AsRef<Path>, OutPath: AsRef<Path>>(
-        path: DiskPath,
+    fn from_file_on_disk_trimmed(path: &Path, keep_children: usize) -> Result<Self, std::io::Error> {
+        let contents = std::fs::read(path)?;
+        let archive_path = Self::trim_path_components(path, keep_children);
+        Self::file(&archive_path, contents).with_metadata_from_disk(path)
+    }
+    
+    /// Recursively walks `path` on disk, pushing one `Directory` entry for path (in case dir is empty)
+    /// and then goes though each child and creates archive entries for each child, joining the child's name
+    /// to this directory's reference `archive_path` to ensure file at `path/a/b.txt` gets the path
+    /// `archive_path/a/b.txt`, not just `archive_path` (previous bug)
+    fn from_directory_on_disk(
+        disk_path: &Path,
         entries: &mut Vec<Self>,
-        depth: Option<usize>,
-        out_path: Option<OutPath>,
+        archive_path: &Path,
     ) -> Result<(), std::io::Error> {
-        let path = path.as_ref();
-        // depth should always start at 1 so we include the current directory name
-        let depth = depth.unwrap_or(1);
-
-        let directory_name = if let Some(ref out) = out_path {
-            out.as_ref().as_os_str()
-        } else {
-            path.file_name().unwrap_or(std::ffi::OsStr::new("directory name not present"))
-        };
-
-        let directory_entry = Self::directory(directory_name).with_metadata_from_disk(path)?;
+        let directory_entry = Self::directory(archive_path).with_metadata_from_disk(disk_path)?;
         entries.push(directory_entry);
-        
-        for entry in std::fs::read_dir(path)? {
+
+        for entry in std::fs::read_dir(disk_path)? {
             let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                return Self::from_directory_on_disk(path, entries, Some(depth + 1), out_path);
-            } else if path.is_file() {
-                let f = match Self::from_file_on_disk(&path, depth + 1, &out_path) {
+            let disk_path = entry.path();
+            #[allow(clippy::disallowed_methods, reason = "entry.file_name() cannot start with root sep")]
+            let child_archive_path = archive_path.join(entry.file_name());
+
+            if disk_path.is_dir() {
+                Self::from_directory_on_disk(&disk_path, entries, &child_archive_path)?;
+            } else if disk_path.is_file() {
+                let f = match Self::from_file_on_disk(&disk_path, &child_archive_path) {
                     Ok(e) => e,
                     Err(err) => {
-                        return Err(std::io::Error::other(format!("failed to handle path '{}' due to err: {}", path.display(), err)));
+                        return Err(std::io::Error::other(format!("failed to handle path '{}' due to err: {}", disk_path.display(), err)));
                     }
                 };
                 entries.push(f);
@@ -277,18 +276,30 @@ impl WrappedArchiveEntry {
         inner.symlink_target().map(|tar| tar.to_owned())
     }
 
-    fn from_path_on_disk(path: &Path, out_path: Option<&Path>) -> LuaResult<Entries> {
+    fn from_path_on_disk(path: &Path, out_path: Option<ArchiveOutputPath>) -> LuaResult<Entries> {
+        let function_name = "entry.read(path: Pathlike, as: (Pathlike | number)?)";
         if path.is_file() {
-            match Self::from_file_on_disk(path, 1, &out_path) {
+            let result = match out_path {
+                Some(ArchiveOutputPath::As(out)) => Self::from_file_on_disk(path, &out),
+                Some(ArchiveOutputPath::KeepChildren(n)) => Self::from_file_on_disk_trimmed(path, n),
+                None => Self::from_file_on_disk_trimmed(path, 1),
+            };
+            match result {
                 Ok(entry) => Ok(Entries::One(entry)),
                 Err(err) => {
-                    wrap_io_read_errors(err, "idkf", path)
+                    wrap_io_read_errors(err, function_name, path)
                 }
             }
         } else if path.is_dir() {
+            let archive_path = match out_path {
+                Some(ArchiveOutputPath::As(out)) => out,
+                Some(ArchiveOutputPath::KeepChildren(n)) => Self::trim_path_components(path, n),
+                None => Self::trim_path_components(path, 1),
+            };
+
             let mut entries = Vec::new();
-            if let Err(err) = Self::from_directory_on_disk(path, &mut entries, None, out_path) {
-                return wrap_io_read_errors(err, "idkd", path);
+            if let Err(err) = Self::from_directory_on_disk(path, &mut entries, &archive_path) {
+                return wrap_io_read_errors(err, function_name, path);
             }
             Ok(Entries::Many(entries))
         } else {
@@ -469,10 +480,10 @@ impl WrappedArchiveEntry {
         let mtime = inner.mtime();
 
         let path = Path::new(&destination);
-        if let Some(parent) = path.parent() {
-            if let Err(err) = std::fs::create_dir_all(parent) {
-                return wrap_io_read_errors_empty(err, function_name, parent);
-            }
+        if let Some(parent) = path.parent() 
+            && let Err(err) = std::fs::create_dir_all(parent)
+        {
+            return wrap_io_read_errors_empty(err, function_name, parent);
         }
 
         if let Err(err) = std::fs::write(path, data) {
@@ -684,21 +695,26 @@ fn entry_create_symlink(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueRe
 }
 
 fn entry_read(luau: &Lua, mut multivalue: LuaMultiValue) -> LuaValueResult {
-    let function_name = "entry.read(path: Pathlike, as: Pathlike?)";
+    let function_name = "entry.read(path: Pathlike, as: (Pathlike | number)?)";
 
     let path = super::expect_pathlike(multivalue.pop_front(), function_name)?;
     let out_path = match multivalue.pop_front() {
         Some(LuaValue::String(s)) => {
-            let owned = s.to_string_lossy();
-            Some(PathBuf::from(owned))
+            Some(ArchiveOutputPath::As(PathBuf::from(s.to_string_lossy())))
+        },
+        Some(LuaValue::Integer(i)) => {
+            Some(ArchiveOutputPath::KeepChildren(int_to_usize(i, function_name, "as")?))
+        },
+        Some(LuaValue::Number(f)) => {
+            Some(ArchiveOutputPath::KeepChildren(float_to_usize(f, function_name, "as")?))
         },
         Some(LuaNil) | None => None,
         Some(other) => {
-            return wrap_err!("{}: expected as to be a string, got: {:?}", function_name, other);
+            return wrap_err!("{}: expected as to be a string or number, got: {:?}", function_name, other);
         }
     };
 
-    WrappedArchiveEntry::from_path_on_disk(Path::new(&path), out_path.as_deref())?.into_value(luau)
+    WrappedArchiveEntry::from_path_on_disk(Path::new(&path), out_path)?.into_value(luau)
 }
 
 pub fn create(luau: &Lua) -> LuaResult<LuaTable> {

--- a/tests/luau/std/archive/entry.luau
+++ b/tests/luau/std/archive/entry.luau
@@ -1,0 +1,132 @@
+-- tests entry.read: reading files/directories off disk into ArchiveEntry/{ ArchiveEntry }
+
+local entry = require("@std/archive/entry")
+local archive = require("@std/archive")
+local fs = require("@std/fs")
+
+const temp_path = fs.path.join(script:parent(), "temp_entry_read")
+fs.dir.try_remove(temp_path)
+fs.dir.ensure(temp_path, true)
+
+--[=[
+    project/
+        root.txt
+        src/
+            main.txt
+            utils/
+                helper.txt
+        docs/
+            readme.txt
+]=]
+const project_path = fs.path.join(temp_path, "project")
+fs.writetree(project_path, fs.tree()
+    :with_file("root.txt", "root")
+    :with_tree("src", fs.tree()
+        :with_file("main.txt", "main")
+        :with_tree("utils", fs.tree()
+            :with_file("helper.txt", "helper")
+        )
+    )
+    :with_tree("docs", fs.tree()
+        :with_file("readme.txt", "readme")
+    )
+)
+
+local function paths_of(entries: { ArchiveEntry }): { string }
+    const paths = {}
+    for _, e in entries do
+        table.insert(paths, e:path())
+    end
+    table.sort(paths)
+    return paths
+end
+
+local function contains(paths: { string }, path: string): boolean
+    for _, p in paths do
+        if p == path then
+            return true
+        end
+    end
+    return false
+end
+
+-- reading a directory with no `as` roots everything under the directory's own basename,
+-- and every file/subdirectory is visited exactly once (regression test: previously only
+-- the *first* subdirectory encountered was recursed into, and every nested file's path
+-- was clobbered to be the same as the (nonexistent) `as` argument instead of joined)
+const default_entries = entry.read(project_path) :: { ArchiveEntry }
+assert(type(default_entries) == "table", "reading a directory should return a table of entries")
+const default_paths = paths_of(default_entries)
+
+assert(#default_entries == 8, `expected 8 entries (4 directories + 4 files), got {#default_entries}`)
+assert(contains(default_paths, "project"), "missing root directory entry 'project'")
+assert(contains(default_paths, "project/root.txt"), "missing 'project/root.txt'")
+assert(contains(default_paths, "project/src"), "missing 'project/src' directory entry")
+assert(contains(default_paths, "project/src/main.txt"), "missing 'project/src/main.txt'")
+assert(contains(default_paths, "project/src/utils"), "missing 'project/src/utils' directory entry")
+assert(contains(default_paths, "project/src/utils/helper.txt"), "missing 'project/src/utils/helper.txt'")
+assert(contains(default_paths, "project/docs"), "missing 'project/docs' directory entry")
+assert(contains(default_paths, "project/docs/readme.txt"), "missing 'project/docs/readme.txt'")
+
+-- no entry should have collapsed to just "project" (the old bug: every nested file/dir
+-- got the top-level `as`/basename verbatim instead of having its relative path joined on)
+local misplaced = 0
+for _, p in default_paths do
+    if p == "project" then
+        misplaced += 1
+    end
+end
+assert(misplaced == 1, `expected exactly 1 entry at path "project" (the root dir itself), got {misplaced}`)
+
+-- file contents/paths actually correspond to the right entry, not swapped/duplicated
+const as_archive = archive.create()
+as_archive:append(default_entries)
+const main_txt = as_archive:expect("project/src/main.txt")
+assert(main_txt:expect_file():contents() == "main", "project/src/main.txt has wrong contents")
+const helper_txt = as_archive:expect("project/src/utils/helper.txt")
+assert(helper_txt:expect_file():contents() == "helper", "project/src/utils/helper.txt has wrong contents")
+const readme = as_archive:expect("project/docs/readme.txt")
+assert(readme:expect_file():contents() == "readme", "project/docs/readme.txt has wrong contents")
+
+-- `as` as a string re-roots the whole tree, joining nested paths onto it (not overwriting them)
+const rerooted_entries = entry.read(project_path, "custom/root") :: { ArchiveEntry }
+const rerooted_paths = paths_of(rerooted_entries)
+assert(contains(rerooted_paths, "custom/root"), "missing re-rooted directory entry 'custom/root'")
+assert(contains(rerooted_paths, "custom/root/root.txt"), "missing 'custom/root/root.txt'")
+assert(contains(rerooted_paths, "custom/root/src/main.txt"), "missing 'custom/root/src/main.txt'")
+assert(contains(rerooted_paths, "custom/root/src/utils/helper.txt"), "missing 'custom/root/src/utils/helper.txt'")
+assert(not contains(rerooted_paths, "project"), "re-rooted read should not contain any 'project'-rooted paths")
+
+-- `as` as a number keeps that many trailing path components of the directory being read,
+-- instead of just its own basename
+const kept_entries = entry.read(project_path, 2) :: { ArchiveEntry }
+const kept_paths = paths_of(kept_entries)
+const expected_root = fs.path.join("temp_entry_read", "project")
+assert(contains(kept_paths, expected_root), `missing kept-components root directory entry '{expected_root}'`)
+assert(
+    contains(kept_paths, fs.path.join(expected_root, "src", "main.txt")),
+    `missing '{fs.path.join(expected_root, "src", "main.txt")}'`
+)
+
+-- reading a single file with no `as` defaults to just the file's own basename
+const single_default = entry.read(fs.path.join(project_path, "src", "main.txt")) :: ArchiveEntry
+assert(single_default:path() == "main.txt", `expected single file default path "main.txt", got {single_default:path()}`)
+assert(single_default:expect_file():contents() == "main", "single file default read has wrong contents")
+
+-- reading a single file with a string `as` uses it as the exact archive path, nested or not
+const single_named = entry.read(fs.path.join(project_path, "src", "main.txt"), "renamed/main.txt") :: ArchiveEntry
+assert(single_named:path() == "renamed/main.txt", `expected "renamed/main.txt", got {single_named:path()}`)
+
+-- reading a single file with a numeric `as` keeps that many trailing path components
+const single_kept = entry.read(fs.path.join(project_path, "src", "main.txt"), 2) :: ArchiveEntry
+assert(single_kept:path() == fs.path.join("src", "main.txt"), `expected "src/main.txt", got {single_kept:path()}`)
+
+-- an empty directory still produces its own (empty) Directory entry, not nothing
+const empty_dir = fs.path.join(temp_path, "empty")
+fs.dir.ensure(empty_dir, true)
+const empty_entries = entry.read(empty_dir) :: { ArchiveEntry }
+assert(#empty_entries == 1, `expected exactly 1 entry (the empty dir itself), got {#empty_entries}`)
+assert(empty_entries[1].type == "Directory", "the sole entry for an empty directory should be a Directory")
+assert(empty_entries[1]:path() == "empty", `expected path "empty", got {empty_entries[1]:path()}`)
+
+fs.dir.try_remove(temp_path)


### PR DESCRIPTION
I made a mistake with how I handled keep_children and path trimming, fixed it to preserve nested directory structure and not create unneeded top level dirs