### PR TITLE
Rename ArchiveEntry:as_x to :try_x to match seal conventions

### DIFF
--- a/.seal/typedefs/globals.d.luau
+++ b/.seal/typedefs/globals.d.luau
@@ -172,7 +172,7 @@ declare extern type ArchiveEntry with
     --[=[
         Narrow this into an `ArchiveEntryFile` if this entry represents a File.
     ]=]
-    function as_file(self): ArchiveEntryFile?
+    function try_file(self): ArchiveEntryFile?
     --[=[
         Expect/assert that this entry should be an `ArchiveEntryFile`, throwing an error if it isn't.
     ]=]
@@ -181,7 +181,7 @@ declare extern type ArchiveEntry with
     --[=[
         Narrow this into an `ArchiveEntryDirectory` if this entry represents a Directory.
     ]=]
-    function as_directory(self): ArchiveEntryDirectory?
+    function try_directory(self): ArchiveEntryDirectory?
     --[=[
         Expect/assert that this entry should be an `ArchiveEntryDirectory`, throwing an error if it isn't.
     ]=]
@@ -190,7 +190,7 @@ declare extern type ArchiveEntry with
     --[=[
         Narrow this into an `ArchiveEntrySymlink` if this entry represents a Symlink.
     ]=]
-    function as_symlink(self): ArchiveEntrySymlink?
+    function try_symlink(self): ArchiveEntrySymlink?
     --[=[
         Expect/assert that this entry should be an `ArchiveEntrySymlink`, throwing an error if it isn't.
     ]=]

--- a/src/std_archive/entry.rs
+++ b/src/std_archive/entry.rs
@@ -321,7 +321,7 @@ impl WrappedArchiveEntry {
         }
     }
 
-    fn entry_as_self(luau: &Lua, this: &WrappedArchiveEntry, what: EntryType) -> LuaValueResult {
+    fn entry_try_self(luau: &Lua, this: &WrappedArchiveEntry, what: EntryType) -> LuaValueResult {
         let inner = this.inner.borrow();
         let success = match what {
             EntryType::File => inner.is_file(),
@@ -335,8 +335,8 @@ impl WrappedArchiveEntry {
         }
     }
 
-    fn entry_as_file(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
-        Self::entry_as_self(luau, this, EntryType::File)
+    fn entry_try_file(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
+        Self::entry_try_self(luau, this, EntryType::File)
     }
 
     fn entry_expect_file(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
@@ -344,8 +344,8 @@ impl WrappedArchiveEntry {
         Self::entry_expect_self(luau, this, EntryType::File, function_name)
     }
 
-    fn entry_as_directory(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
-        Self::entry_as_self(luau, this, EntryType::Directory)
+    fn entry_try_directory(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
+        Self::entry_try_self(luau, this, EntryType::Directory)
     }
 
     fn entry_expect_directory(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
@@ -353,8 +353,8 @@ impl WrappedArchiveEntry {
         Self::entry_expect_self(luau, this, EntryType::Directory, function_name)
     }
 
-    fn entry_as_symlink(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
-        Self::entry_as_self(luau, this, EntryType::Symlink)
+    fn entry_try_symlink(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
+        Self::entry_try_self(luau, this, EntryType::Symlink)
     }
 
     fn entry_expect_symlink(luau: &Lua, this: &WrappedArchiveEntry, _: LuaValue) -> LuaValueResult {
@@ -607,11 +607,11 @@ impl LuaUserData for WrappedArchiveEntry {
         );
     }
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
-        methods.add_method("as_file", WrappedArchiveEntry::entry_as_file);
+        methods.add_method("try_file", WrappedArchiveEntry::entry_try_file);
         methods.add_method("expect_file", WrappedArchiveEntry::entry_expect_file);
-        methods.add_method("as_directory", WrappedArchiveEntry::entry_as_directory);
+        methods.add_method("try_directory", WrappedArchiveEntry::entry_try_directory);
         methods.add_method("expect_directory", WrappedArchiveEntry::entry_expect_directory);
-        methods.add_method("as_symlink", WrappedArchiveEntry::entry_as_symlink);
+        methods.add_method("try_symlink", WrappedArchiveEntry::entry_try_symlink);
         methods.add_method("expect_symlink", WrappedArchiveEntry::entry_expect_symlink);
         methods.add_method("size", WrappedArchiveEntry::file_get_size);
         methods.add_method("contents", WrappedArchiveEntry::file_get_contents);

--- a/tests/luau/std/archive/entry.luau
+++ b/tests/luau/std/archive/entry.luau
@@ -129,4 +129,32 @@ assert(#empty_entries == 1, `expected exactly 1 entry (the empty dir itself), go
 assert(empty_entries[1].type == "Directory", "the sole entry for an empty directory should be a Directory")
 assert(empty_entries[1]:path() == "empty", `expected path "empty", got {empty_entries[1]:path()}`)
 
+-- :try_file()/:try_directory()/:try_symlink() narrow to the matching type, returning nil (not erroring)
+-- when self isn't that type; :expect_file()/etc should still error in that case
+const file_entry = entry.create.file("some.txt", "contents")
+const dir_entry = entry.create.directory("some_dir")
+const symlink_entry = entry.create.symlink("some_link", "some.txt")
+
+assert(file_entry:try_file() ~= nil, "try_file on a File entry should return itself, not nil")
+assert(file_entry:try_directory() == nil, "try_directory on a File entry should return nil")
+assert(file_entry:try_symlink() == nil, "try_symlink on a File entry should return nil")
+
+assert(dir_entry:try_directory() ~= nil, "try_directory on a Directory entry should return itself, not nil")
+assert(dir_entry:try_file() == nil, "try_file on a Directory entry should return nil")
+assert(dir_entry:try_symlink() == nil, "try_symlink on a Directory entry should return nil")
+
+assert(symlink_entry:try_symlink() ~= nil, "try_symlink on a Symlink entry should return itself, not nil")
+assert(symlink_entry:try_file() == nil, "try_file on a Symlink entry should return nil")
+assert(symlink_entry:try_directory() == nil, "try_directory on a Symlink entry should return nil")
+
+assert(pcall(function()
+    return dir_entry:expect_file()
+end) == false, "expect_file on a Directory entry should error, not return nil")
+assert(pcall(function()
+    return file_entry:expect_directory()
+end) == false, "expect_directory on a File entry should error, not return nil")
+assert(pcall(function()
+    return file_entry:expect_symlink()
+end) == false, "expect_symlink on a File entry should error, not return nil")
+
 fs.dir.try_remove(temp_path)


### PR DESCRIPTION
:as should be used for nonthrowing, nonniling conversions, try used for getting self without throwing error (returning nil), expect for throwing error